### PR TITLE
Integrated bolt to execute unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Generated
+output/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/boltfile.py
+++ b/boltfile.py
@@ -1,0 +1,106 @@
+import os.path
+
+import bolt
+
+
+# DEVELOPMENT TASKS
+bolt.register_task('default', [
+    'pip',
+    'run-unit-tests',
+])
+bolt.register_task('ut', [
+    'run-unit-tests'
+])
+bolt.register_task('ct', [
+    'conttest'
+])
+
+# CI/CD TASKS
+bolt.register_task('execute-unit-tests', [
+    'clear-pyc-testing',
+    'mkdir',
+    'mkdir.tests',
+    'mkdir.tests.coverage',
+    'nose.ci',
+])
+
+# HELPER TASKS
+bolt.register_task('clear-pyc-testing',[
+    'delete-pyc',
+    'delete-pyc.tests',
+])
+bolt.register_task('clear-pyc-features', [
+    'delete-pyc',
+    'delete-pyc.features'
+])
+bolt.register_task('run-unit-tests', [
+    'clear-pyc-testing',
+    'nose',
+])
+
+
+
+
+# CONFIGURATION CONSTANTS
+PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
+SRC_DIR = os.path.join(PROJECT_ROOT, 'behave_restful')
+TESTS_DIR = os.path.join(PROJECT_ROOT, 'tests')
+FEATURES_DIR = os.path.join(PROJECT_ROOT, 'features')
+DOCS_DIR = os.path.join(PROJECT_ROOT, 'docs')
+OUTPUT_DIR = os.path.join(PROJECT_ROOT, 'output')
+
+REQUIREMENTS_FILE = os.path.join(PROJECT_ROOT, 'requirements.txt')
+
+TESTS_RESULTS_DIR = os.path.join(OUTPUT_DIR, 'tests', 'results')
+TESTS_RESULTS_FILE = os.path.join(TESTS_RESULTS_DIR, 'unit_tests_results.xml')
+TESTS_COVERAGE_DIR = os.path.join(OUTPUT_DIR, 'tests', 'coverage')
+
+
+
+
+
+
+config = {
+    'pip': {
+        'command': 'install',
+        'options': {
+            'r': REQUIREMENTS_FILE,
+        }
+    },
+    'delete-pyc': {
+        'sourcedir': SRC_DIR,
+        'recursive': True,
+        'tests': {
+            'sourcedir': TESTS_DIR,
+        },
+        'features': {
+            'sourcedir': FEATURES_DIR
+        }
+    },
+    'nose': {
+        'directory': TESTS_DIR,
+        'ci': {
+            'options': {
+                'with-xunit': True,
+                'xunit-file': TESTS_RESULTS_FILE,
+                'with-coverage': True,
+                'cover-erase': True,
+                'cover-package': 'behave-restful',
+                'cover-html-dir': TESTS_COVERAGE_DIR,
+                'cover-branches': True,
+            }
+        }
+    },
+    'conttest': {
+        'task': 'run-unit-tests'
+    },
+    'mkdir': {
+        'directory': OUTPUT_DIR,
+        'tests': {
+            'directory': TESTS_RESULTS_DIR,
+            'coverage': {
+                'directory': TESTS_COVERAGE_DIR
+            }
+        },
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ bolt-ta>=0.2.5
 conttest>=0.0.8
 coverage>=4.1
 nose>=1.3.7
+pylint>=1.7.4
 sphinx>=1.3

--- a/tests/test_to_be_removed.py
+++ b/tests/test_to_be_removed.py
@@ -1,0 +1,11 @@
+import unittest
+
+
+class TestWillBeRemoved(unittest.TestCase):
+
+    def test_will_succeed(self):
+        self.assertTrue(True)
+
+
+if __name__=="__main__":
+    unittest.main()


### PR DESCRIPTION
This submission contains the following changes:
- Added `boltfile.py` and configured tasks to run unit tests in development and CI/CD. The CI/CD tasks fail because we are using `coverage.py` but there is no code to be covered yet. I will take a look at those tasks once code is added.
- Added the `output` directory to `.gitignore`.
- Added a sample test to insure things were executing correctly and working. This test and module will be removed once the implementation starts.