### PR TITLE
Adds Support for Variable Definitions

### DIFF
--- a/behave_restful/_definitions.py
+++ b/behave_restful/_definitions.py
@@ -1,0 +1,194 @@
+"""
+This module exposes functionality to handle definition files in the application.
+"""
+import os
+
+import behave_restful._errors as _errors
+import behave_restful._utils as _utils
+import behave_restful.xpy as xpy
+
+DEFINITIONS_DIR = 'definitions'
+DEFINITION_KEY = 'definition'
+class DefinitionInitializer(object):
+    """
+    Initializes definitions into the execution context.
+    """
+    
+    def initialize(self, context):
+        """
+        Initializes the specified definition, if exists, into the execution
+        context.
+
+        :param context:
+            Context object to initialize.
+        """
+        context.vars = VarsManager()
+        self._add_to_search_path(context.test_dir, DEFINITIONS_DIR)
+        if DEFINITION_KEY in context.config.userdata:
+            self._initialize_definition(context)
+
+
+    def _add_to_search_path(self, *path_tokens):
+        _utils.add_search_path(*path_tokens)
+
+
+    def _initialize_definition(self, context):
+        definition_name = context.config.userdata[DEFINITION_KEY]
+        definition_module = self._load_definition(definition_name)
+        if not definition_module: raise DefinitionNotFoundError(definition_name)
+        definition_module.initialize_definition(context)
+
+
+    def _load_definition(self, definition_name):
+        return _utils.load_module(definition_name)
+
+
+
+
+
+VAR_PREFIX = '${'
+VAR_SUFFIX = '}'
+
+_NO_NEXT_VAR = None
+
+class VarsManager(object):
+    """
+    Manages access and resolution of variables defined in definition files or
+    in the environment.
+    """
+    def __init__(self):
+        self._definitions = {}
+
+
+    def add(self, var_name, var_value):
+        """
+        Adds a new variable. If the variable already existed, the value is
+        overwritten.
+
+        :param str var_name: 
+            Name of the variable to add.
+        :param var_value: 
+            Value to set the variable to.
+        :type var_value:
+            any
+        """
+        self._definitions[var_name] = var_value
+
+
+    def add_vars(self, definitions):
+        """
+        Adds all the variables specified in the definition. 
+        
+        The definition parameter must be a dictionary where the keys are used as 
+        variable names and the values as the values for the variables. Existing 
+        variables will be replaced.
+
+        :param dict definitions:
+            Dictionary containing the variable definitions.
+        """
+        self._definitions.update(definitions)
+
+
+    def get(self, var_name, def_value=None):
+        """
+        Returns the resolved value of a variable.
+
+        :param str var_name:
+            Name of the variable to retrieve value.
+        :param def_value:
+            Optional default value to be returned if the variable is not 
+            defined.
+
+        :return:
+            The resolved value of the variable.
+        """
+        environment_value = os.environ.get(var_name)
+        value = environment_value or self._definitions.get(var_name, def_value)
+        return self.resolve(value) if xpy.is_string(value) else value
+        
+
+    def resolve(self, to_resolve):
+        """
+        Resolves a string containing embedded variables.
+
+        :param str to_resolve:
+            String in which we want to resolve the embedded variables.
+        
+        :return:
+            The string with embedded variables resolved or the same string if
+            variable cannot be resolved or the string does not contain embedded
+            variables.
+        :rtype:
+            str
+
+        The following code sample shows how this function works:
+
+        ..  code-block:: python
+
+            variable_definitions = {
+                'INT_VAR': 1,
+                'STR_VAR': 'a string',
+                'EMBEDDED_VARS': 'contains ${INT_VAR} and ${STR_VAR},
+            }
+
+            manager = VarsManager()
+            manager.add_vars(variable_definitions)
+
+            manager.resolve('contains ${INT_VAR}')
+            # returns 'contains 1'
+
+            manager.resolve('contains ${STR_VAR}')
+            # returns 'contains a string'
+
+            manager.resolve('contains ${INT_VAR} and ${STR_VAR}')
+            # returns 'contains 1 and a string'
+
+            manager.resolve('this ${EMBEDDED_VARS}')
+            # returns 'this contains 1 and a string'
+
+            manager.resolve('this is ${UNDEFINED}')
+            # returns 'this is ${UNDEFINED}'
+        """
+        resolved = to_resolve
+        next_var_name = self._find_var_name_in(resolved)
+        while next_var_name:
+            resolved, next_var_name = self._resolve_in(resolved, next_var_name)
+        return resolved
+
+
+    def _resolve_in(self, to_resolve, var_name):
+        value = self.get(var_name)
+        return self._do_resolve_in(to_resolve, var_name, value) if value is not None else (to_resolve, _NO_NEXT_VAR)
+
+
+    def _do_resolve_in(self, to_resolve, var_name, value):
+        resolved = self._replace_with(to_resolve, var_name, value)
+        next_var_name = self._find_var_name_in(resolved)
+        return resolved, next_var_name
+
+
+
+    def _find_var_name_in(self, to_resolve):
+        var_starts = to_resolve.find(VAR_PREFIX) + len(VAR_PREFIX)
+        var_ends = to_resolve.find(VAR_SUFFIX, var_starts)
+        return to_resolve[var_starts:var_ends]
+
+
+    def _replace_with(self, to_resolve, var_name, value):
+        token = ''.join([VAR_PREFIX, var_name, VAR_SUFFIX])
+        return to_resolve.replace(token, str(value))
+
+
+
+class DefinitionNotFoundError(_errors.BehaveRestfulException):
+    """
+    """
+    def __init__(self, definition_name):
+        self.definition_name = definition_name
+
+
+    def __repr__(self):
+        return "DefinitionNotFoundError(definition_name='{dn}')".format(dn=self.definition_name)
+
+
+    

--- a/behave_restful/_errors.py
+++ b/behave_restful/_errors.py
@@ -1,0 +1,15 @@
+"""
+Contains exception base classes for Behave Restful.
+"""
+
+class BehaveRestfulException(Exception):
+    """
+    Base class for exceptions raised by behave_restful.
+    """
+
+    def __str__(self):
+        return self.__repr__()
+
+
+    def __repr__(self):
+        return "BehaveResfulException('Unknown Error')"

--- a/behave_restful/_utils.py
+++ b/behave_restful/_utils.py
@@ -1,0 +1,38 @@
+"""
+This module provides internal utility functions that are used by the framework
+implementation and should not be needed by users of the framework.
+"""
+import imp
+import os.path
+import sys
+
+
+def add_search_path(*path_tokens):
+    """
+    Adds the specified directory to the Python search path.
+
+    :param *args:
+        List of arguments, as used with ``os.path.join()`` that compose the
+        directory to be added.
+    """
+    full_path = os.path.join(*path_tokens)
+    if full_path not in sys.path:
+        sys.path.insert(0, os.path.abspath(full_path))
+
+
+
+def load_module(module_name):
+    """
+    Dynamically imports the specified module and returns it.
+
+    :param str module_name:
+        Name of the module to be imported as a string. 
+    """
+    module_file = None
+    try:
+        module_file, pathname, description = imp.find_module(module_name)
+        module = imp.load_module(module_name, module_file, pathname, description)
+        return module
+    finally:
+        if module_file:
+            module_file.close()

--- a/behave_restful/app.py
+++ b/behave_restful/app.py
@@ -5,6 +5,8 @@ simplify testing.
 """
 import os
 
+import behave_restful._definitions as _defs
+
 class BehaveRestfulApp(object):
     """
     Behave Restful application class used to initialize the execution context
@@ -24,4 +26,9 @@ class BehaveRestfulApp(object):
         """
         context.test_dir = test_dir
         context.working_dir = os.getcwd()
+        _defs.DefinitionInitializer().initialize(context)
+
+
+    
+
     

--- a/behave_restful/bolt_behave_restful.py
+++ b/behave_restful/bolt_behave_restful.py
@@ -26,12 +26,15 @@ class RunBehaveRestfulTask(object):
             raise FeaturesDirectoryNotSpecifiedError()
         if not self._exists(self.features_dir): 
             raise FeaturesDirectoryDoesNotExistError(self.features_dir)
+        self.definition = self.config.get('definition')
         self.options = self.config.get('options') or {}
 
 
     def _execute(self):
         options_parser = BehaveOptionsParser()
         arguments = options_parser.parse(self.options)
+        if self.definition:
+            arguments.extend(['-D', 'definition={d}'.format(d=self.definition)])
         arguments.append(self.features_dir)
         result = self._invoke_behave(arguments)
         if result != 0: raise FeatureTestsFailedError()

--- a/behave_restful/xpy.py
+++ b/behave_restful/xpy.py
@@ -1,0 +1,30 @@
+"""
+This module provides utilities to write cross-version python code.
+"""
+import sys
+
+PYTHON_VERSION_INFO = sys.version_info
+PYTHON_MAYOR_VERSION = PYTHON_VERSION_INFO[0]
+
+if PYTHON_MAYOR_VERSION == 3:
+    BASE_STRING_TYPE = str
+else:
+    BASE_STRING_TYPE = basestring
+
+
+
+def is_string(value):
+    """
+    Returns whether the specified value is a version independent string.
+
+    :param value:
+        Value we want to evalute
+
+    :return:
+        Boolean indicating if the value is a string. In Python 2.7 is an 
+        object derived from ``basestring`` and in Python 3.x is an instance
+        of ``str``.
+    """
+    return isinstance(value, BASE_STRING_TYPE)
+
+

--- a/boltfile.py
+++ b/boltfile.py
@@ -113,6 +113,7 @@ config = {
     },
     'behave-restful': {
         'directory': FEATURES_DIR,
+        'definition': 'br_test',
         'options': {
             'format': 'progress2'
         },

--- a/features/application_initialization.feature
+++ b/features/application_initialization.feature
@@ -6,3 +6,7 @@ Feature: Application Initialization
     Scenario: The context is initialized with application directories
         Then the context exposes the working directory
             And the context exposes the test directory
+
+
+    Scenario: The context is initialized with the specified definition
+        Then the definition var BR_TESTING_STATUS has a value of running 

--- a/features/definitions/br_test.py
+++ b/features/definitions/br_test.py
@@ -1,0 +1,9 @@
+"""
+"""
+
+vars = {
+    'BR_TESTING_STATUS': 'running'
+}
+
+def initialize_definition(context):
+    context.vars.add_vars(vars)

--- a/features/steps/application_initialization_steps.py
+++ b/features/steps/application_initialization_steps.py
@@ -13,3 +13,9 @@ def step_impl(context):
     this_directory = os.path.dirname(__file__)
     expected_directory = os.path.abspath(os.path.join(this_directory, '..'))
     assert_that(context.test_dir).is_equal_to(expected_directory)
+
+
+@then('the definition var {var} has a value of {value}')
+def step_impl(context, var, value):
+    actual_value = context.vars.get(var)
+    assert_that(actual_value).is_equal_to(value)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -22,7 +22,10 @@ class TestBehaveRestfulApp(unittest.TestCase):
         assert_that(self.context.working_dir, os.getcwd())
 
 
-class ContextDouble(object): pass
+class ContextDouble(object):
+    def __init__(self):
+        self.config = self
+        self.userdata = {}
 
 
 

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,0 +1,211 @@
+import os
+import unittest
+
+from assertpy import assert_that
+
+import behave_restful._definitions as br_definitions
+
+
+class TestDefinitionInitializer(unittest.TestCase):
+
+    def setUp(self):
+        # Mocks context expected properties
+        self.context_mock = self
+        self.config = self
+        self.userdata = {}
+        self.test_dir = 'test_dir'
+        self.initializer = DefinitionInitializerSpy()
+        
+
+    def test_adds_definitions_directory_to_search_path(self):
+        self.with_initializer()
+        assert_that(self.initializer.added_search_path).is_equal_to(os.path.join(self.test_dir, 'definitions'))
+
+
+    def test_loads_definition_if_specifed(self):
+        self.userdata.update(definition='dev')
+        self.with_initializer()
+        assert_that(self.initializer.loaded_definition).is_equal_to('dev')
+
+
+    def test_does_not_load_definition_if_not_specified(self):
+        self.with_initializer()
+        assert_that(self.initializer.loaded_definition).is_none()
+
+
+    def test_raises_if_definition_module_cannot_be_imported(self):
+        self.userdata.update(definition='dev')
+        self.initializer.definition_module = None
+        with self.assertRaises(br_definitions.DefinitionNotFoundError):
+            self.with_initializer()
+
+
+    def test_invokes_definition_module_initialization_with_context(self):
+        self.userdata.update(definition='dev')
+        self.with_initializer()
+        assert_that(self.initializer.specified_context).is_same_as(self.context_mock)
+
+
+    def test_invoked_context_has_a_vars_manager(self):
+        self.userdata.update(definition='dev')
+        self.with_initializer()
+        assert_that(self.initializer.specified_context.vars).is_instance_of(br_definitions.VarsManager)
+
+
+    def with_initializer(self):
+        self.initializer.initialize(self.context_mock)
+
+
+
+class DefinitionInitializerSpy(br_definitions.DefinitionInitializer):
+    def __init__(self):
+        self.added_search_path = None
+        self.loaded_definition = None
+        self.definition_module = self
+        self.specified_context = None
+
+
+    def _add_to_search_path(self, *path_tokens):
+        self.added_search_path = os.path.join(*path_tokens)
+
+
+    def _load_definition(self, definition_name):
+        self.loaded_definition = definition_name
+        return self.definition_module
+
+
+    def initialize_definition(self, context):
+        self.specified_context = context
+        
+
+class TestVarsManager(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.environment_var = 'TEST_ENVIRONMENT_VAR'
+        cls.environment_var_value = 'environment_value'
+        os.environ[cls.environment_var] = cls.environment_var_value
+
+    def setUp(self):
+        self.string_var = 'STRING_VAR'
+        self.string_var_value = 'the string value'
+        self.int_var = 'INT_VAR'
+        self.int_var_value = 1
+        self.composed_var = 'COMPOSED_VAR'
+        self.composed_var_value =  '${STRING_VAR} and ${INT_VAR}'
+        self.composed_var_no_resolution = 'COMPOSED_NO_RESOLUTION'
+        self.composed_var_no_resolution_value = 'this has ${UNDEFINED}'
+        self.defined_vars = {
+            self.string_var: self.string_var_value,
+            self.int_var: self.int_var_value,
+            self.composed_var: self.composed_var_value,
+            self.composed_var_no_resolution: self.composed_var_no_resolution_value,
+        }
+        self.manager = br_definitions.VarsManager()
+        self.manager.add_vars(self.defined_vars)
+
+    def test_returns_specified_variable_value(self):
+        self.assert_var(self.string_var).is_equal_to(self.string_var_value)
+
+
+    def test_returns_specified_value_as_specified_type(self):
+        self.assert_var(self.int_var).is_equal_to(self.int_var_value)
+
+
+    def test_returns_none_if_variable_not_defined(self):
+        self.assert_var('UNDEFINED').is_none()
+
+
+    def test_returns_specified_default_value_if_variable_not_defined(self):
+        def_value = 'default'
+        actual_value = self.manager.get('UNDEFINED', def_value)
+        assert_that(actual_value).is_equal_to(def_value)
+
+
+    def test_additional_variable_definitions_can_be_added(self):
+        self.setup_additional_vars()
+        self.manager.add_vars(self.additional_definitions)
+        self.assert_var(self.another_string_var).is_equal_to(self.another_string_var_value)
+        
+
+    def test_variable_can_be_added(self):
+        self.setup_additional_vars()
+        self.manager.add(self.another_string_var, self.another_string_var_value)
+        self.assert_var(self.another_string_var).is_equal_to(self.another_string_var_value)
+        
+
+    def test_returns_environment_variable_value(self):
+        self.assert_var(self.environment_var).is_equal_to(self.environment_var_value)
+
+
+    def test_envirionment_variables_override_defined_variables(self):
+        self.manager.add(self.environment_var, 'different_value')
+        self.assert_var(self.environment_var).is_equal_to(self.environment_var_value)
+
+
+    def test_returns_resolved_variable_value(self):
+        tokenized_var = 'TOKENIZED'
+        tokenized_var_value = 'contains ${STRING_VAR}'
+        expected_value = 'contains the string value'
+        self.manager.add(tokenized_var, tokenized_var_value)
+        self.assert_var(tokenized_var).is_equal_to(expected_value)
+
+
+    def test_returns_same_string_if_embeded_variable_not_defined(self):
+        no_resolution_string = 'contains ${UNDEFINED} variable'
+        self.assert_resolved(no_resolution_string).is_equal_to(no_resolution_string)
+
+
+    def test_returns_resolved_string_if_variable_is_defined(self):
+        resolution_string = 'contains ${STRING_VAR}'
+        expected_result = 'contains the string value'
+        self.assert_resolved(resolution_string).is_equal_to(expected_result)
+
+
+    def test_resolves_numeric_variables(self):
+        resolution_string = 'contains ${INT_VAR}'
+        expected_result = 'contains 1'
+        self.assert_resolved(resolution_string).is_equal_to(expected_result)
+
+
+    def test_resolves_multiple_embedded_variables(self):
+        resolution_string = 'contains ${INT_VAR} and ${STRING_VAR}'
+        expected_result = 'contains 1 and the string value'
+        self.assert_resolved(resolution_string).is_equal_to(expected_result)
+
+
+    def test_resolves_string_composed_of_other_variables_with_embedded_variables(self):
+        resolution_string = 'contains ${COMPOSED_VAR}'
+        expected_result = 'contains the string value and 1'
+        self.assert_resolved(resolution_string).is_equal_to(expected_result)
+
+
+    def test_returns_partial_resolved_string_if_contains_embedded_with_no_resolution(self):
+        resolution_string = 'embedded: ${COMPOSED_NO_RESOLUTION}'
+        expected_result = 'embedded: this has ${UNDEFINED}'
+        self.assert_resolved(resolution_string).is_equal_to(expected_result)
+
+
+
+    def assert_var(self, var_name):
+        actual_value = self.manager.get(var_name)
+        return assert_that(actual_value)
+
+
+    def assert_resolved(self, to_resolve):
+        actual_value = self.manager.resolve(to_resolve)
+        return assert_that(actual_value)
+
+    
+    def setup_additional_vars(self):
+        self.another_string_var = 'another_var'
+        self.another_string_var_value = 'another_value'
+        self.additional_definitions = {
+            self.another_string_var: self.another_string_var_value
+        }
+        
+
+
+
+if __name__=="__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,33 @@
+import os.path
+import sys
+import unittest
+
+from assertpy import assert_that
+
+import behave_restful._utils as br_utils
+
+class TestAddSearchPath(unittest.TestCase):
+
+    def setUp(self):
+        self.existing_path = os.path.abspath(os.path.dirname(__file__))
+        self.not_existing_path = 'non_existing'
+
+
+    def tearDown(self):
+        if self.existing_path in sys.path:
+            sys.path.remove(self.existing_path)
+
+
+    def test_adds_path_if_exists(self):
+        br_utils.add_search_path(self.existing_path)
+        assert_that(self.existing_path in sys.path).is_true()
+        
+
+    def test_does_not_add_path_if_it_does_not_exist(self):
+        br_utils.add_search_path(self.not_existing_path)
+        assert_that(self.not_existing_path in sys.path).is_false()
+
+
+if __name__=="__main__":
+    unittest.main()
+

--- a/tests/test_xpy.py
+++ b/tests/test_xpy.py
@@ -1,0 +1,18 @@
+import unittest
+
+from assertpy import assert_that
+
+import behave_restful.xpy as xpy
+
+class TestIsString(unittest.TestCase):
+
+    def test_returns_true_if_string(self):
+        assert_that(xpy.is_string('this is a string')).is_true()
+
+
+    def test_returns_false_if_not_a_string(self):
+        assert_that(xpy.is_string(1)).is_false()
+
+
+if __name__=="__main__":
+    unittest.main()


### PR DESCRIPTION
Implementation of variable definitions as documented in issue #4 where variables can be defined, so they become available through the `context` object. The following changes have been made to support the feature:

- The `behave-restful` bolt task supports a `definition` parameter that can be set to a module name located in a `definitions` sub-folder of the test directory (usually the `features` folder). If the specified module is found, it is loaded and its `initialize_definition(context)` function is invoked with the context.
- Added implementation classes to initialize definitions and to handle resolution of variables.
- Modified the application class to invoke the initialization.
- Provided a base class for exceptions raised by `behave_restful`.

## Implementation Notes:

A `VarsManager` is initialized in the context regardless of whether a definition is specified or not. This allows to access environment variables even when no definitions are provided.

The implementation will add the `definitions` folder to the search path if the folder exists. An exception will be raised if a specified definition does not exist and cannot be loaded. 

Variables can be resolved through `context.vars.get()` which supports resolving variables that contain other variables in them.