### PR TITLE
Implemented step to validate values matched by json path

### DIFF
--- a/behave_restful/_lang_imp/response_validator.py
+++ b/behave_restful/_lang_imp/response_validator.py
@@ -2,7 +2,8 @@
 """
 import json
 
-from assertpy import assert_that
+from assertpy import assert_that, fail
+import jsonpath_rw as jp
 import jsonschema
 
 from behave_restful.xpy import HTTPStatus
@@ -21,6 +22,13 @@ def response_json_matches(response, schema_str):
     schema = json.loads(schema_str)
     json_body = response.json()
     jsonschema.validate(json_body, schema)
+
+
+def response_json_matches_at(response, json_path, expected_str):
+    """
+    """
+    values = _get_values(response.json(), json_path)
+    [assert_that(actual_value).is_equal_to(eval(expected_str)) for actual_value in values]
     
 
 
@@ -30,4 +38,11 @@ def _as_numeric_status(status):
     if not numeric_status:
         numeric_status = int(status)
     return numeric_status
+
+
+def _get_values(json_body, json_path):
+    results = jp.parse(json_path).find(json_body)
+    if not results: fail('Match not found at <{path}> for <{body}>'.format(path=json_path, body=json_body))
+    values = [result.value for result in results]
+    return values    
 

--- a/behave_restful/lang/_then_steps.py
+++ b/behave_restful/lang/_then_steps.py
@@ -13,3 +13,10 @@ def step_impl(context, status):
 def step_impl(context):
     schema = context.vars.resolve(context.text)
     _validate.response_json_matches(context.response, schema)
+
+
+@then('the response json at {json_path} is equal to {value_str}')
+def step_impl(context, json_path, value_str):
+    json_path = context.vars.resolve(json_path)
+    value_str = context.vars.resolve(value_str)
+    _validate.response_json_matches_at(context.response, json_path, value_str)

--- a/features/definitions/br_test.py
+++ b/features/definitions/br_test.py
@@ -9,7 +9,11 @@ vars = {
     'RESOURCE_NAME': 'resolved name',
     'TYPE_STRING': '{"type": "string"}',
     'TYPE_NUMBER': '{"type": "number"}',
-    'REQUIRED': 'required'
+    'REQUIRED': 'required',
+    'TITLE_PATH': '$.store.book[3].title',
+    'BOOK_INDEX': 1,
+    'TITLE': 'title',
+    'CATEGORY_FICTION': "fiction"
 }
 
 def initialize_definition(context):

--- a/features/features_lang/then/the_response_json_at_is_equal_to.feature
+++ b/features/features_lang/then/the_response_json_at_is_equal_to.feature
@@ -1,0 +1,81 @@
+Feature: Step then the response json at is equal to
+    Validates the functionality of the step "the response json at <path> is equal to <value>"
+
+
+    Background: We use a response double from where the JSON payload is retrieved.
+        Given a test response
+            And the response contains a json body like
+                """
+                { 
+                    "store": {
+                        "book": [ 
+                        { 
+                            "category": "reference",
+                            "author": "Nigel Rees",
+                            "title": "Sayings of the Century",
+                            "price": 8.95,
+                            "edition": 2
+                        },
+                        { 
+                            "category": "fiction",
+                            "author": "Evelyn Waugh",
+                            "title": "Sword of Honour",
+                            "price": 12.99,
+                            "edition": 6
+                        },
+                        { 
+                            "category": "fiction",
+                            "author": "Herman Melville",
+                            "title": "Moby Dick",
+                            "isbn": "0-553-21311-3",
+                            "price": 8.99,
+                            "edition": 5
+                        },
+                        { 
+                            "category": "fiction",
+                            "author": "J. R. R. Tolkien",
+                            "title": "The Lord of the Rings",
+                            "isbn": "0-395-19395-8",
+                            "price": 22.99,
+                            "edition": 1
+                        }
+                        ],
+                        "bicycle": {
+                        "color": "red",
+                        "price": 19.95
+                        }
+                    }
+                }
+                """
+
+
+    Scenario: Validates value of specific string property
+        Notice the value is surrounded by quotes to indicate is a string.
+
+        Then the response json at $.store.book[0].author is equal to "Nigel Rees"
+
+
+    Scenario: Validates value of specific integer property
+        Notice integer values are not surrounded by quotes.
+
+        Then the response json at $.store.book[2].edition is equal to 5
+
+
+    Scenario: Validates value of specific double property
+        Notice double values are not surrounded by quotes.
+        
+        Then the response json at $.store.book[3].price is equal to 22.99
+
+
+    Scenario: Validates all values in specified range
+        Then the response json at $.store.book[1:4].category is equal to "fiction"
+
+
+    Scenario: Variables can be used in json path
+        Then the response json at ${TITLE_PATH} is equal to "The Lord of the Rings"
+            And the response json at $.store.book[${BOOK_INDEX}].title is equal to "Sword of Honour"
+            And the response json at $.store.book[2].${TITLE} is equal to "Moby Dick"
+
+
+    Scenario: Variables can be used in expected value
+        Then the response json at $.store.book[1:4].category is equal to "${CATEGORY_FICTION}"

--- a/tests/test_lang_imp/test_response_validator.py
+++ b/tests/test_lang_imp/test_response_validator.py
@@ -25,6 +25,46 @@ class TestResponseValidatorInterface(unittest.TestCase):
             "required": ["id", "name"]
         }
         """
+        self.json_body = {
+            "store": {
+                "book": [ 
+                { 
+                    "category": "reference",
+                    "author": "Nigel Rees",
+                    "title": "Sayings of the Century",
+                    "price": 8.95,
+                    "edition": 1
+                },
+                { 
+                    "category": "fiction",
+                    "author": "Evelyn Waugh",
+                    "title": "Sword of Honour",
+                    "price": 12.99,
+                    "edition": 2
+                },
+                { 
+                    "category": "fiction",
+                    "author": "Herman Melville",
+                    "title": "Moby Dick",
+                    "isbn": "0-553-21311-3",
+                    "price": 8.99,
+                    "edition": 3
+                },
+                { 
+                    "category": "fiction",
+                    "author": "J. R. R. Tolkien",
+                    "title": "The Lord of the Rings",
+                    "isbn": "0-395-19395-8",
+                    "price": 22.99,
+                    "edition": 4
+                }
+                ],
+                "bicycle": {
+                "color": "red",
+                "price": 19.95
+                }
+            }
+        }
         self.response = ResponseDouble()        
 
 
@@ -93,6 +133,33 @@ class TestResponseValidatorInterface(unittest.TestCase):
             }).validate()
 
 
+    # response_json_matches_at()
+    def test_matches_specified_property(self):
+        self.given_json(self.json_body).match('$.store.book[0].author', '"Nigel Rees"')
+
+
+    def test_matches_specified_double_property(self):
+        self.given_json(self.json_body).match('$.store.book[1].price', '12.99')
+
+
+    def test_matches_specified_integer_property(self):
+        self.given_json(self.json_body).match('$.store.book[3].edition', '4')
+
+
+    def test_evaluates_all_matches_found(self):
+        self.given_json(self.json_body).match('$.store.book[1:4].category', '"fiction"')
+
+
+    def test_evaluates_all_matches_and_fails_if_any_does_not_match(self):
+        with self.assertRaises(AssertionError):
+            self.given_json(self.json_body).match('$.store.book[*].category', '"reference"')
+
+
+    def test_raises_if_specified_path_does_not_find_matches(self):
+        with self.assertRaises(AssertionError):
+            self.given_json(self.json_body).match('$.not.a.path', 'no match')    
+
+
     def given_json(self, json_object):
         self.response.json_payload = json_object
         return self
@@ -100,6 +167,10 @@ class TestResponseValidatorInterface(unittest.TestCase):
 
     def validate(self):
         _validator.response_json_matches(self.response, self.schema)
+
+
+    def match(self, json_path, expected_value):
+        _validator.response_json_matches_at(self.response, json_path, expected_value)
         
 
 


### PR DESCRIPTION
Implemented step `Then the response json at {json_path} is equal to {value_str}`, which allows to test individual values on a json response, as well as, value ranges. The following shows the feature tests added, which help understanding how the step works:

```gherkin

Feature: Step then the response json at is equal to
    Validates the functionality of the step "the response json at <path> is equal to <value>"


    Background: We use a response double from where the JSON payload is retrieved.
        Given a test response
            And the response contains a json body like
                """
                { 
                    "store": {
                        "book": [ 
                        { 
                            "category": "reference",
                            "author": "Nigel Rees",
                            "title": "Sayings of the Century",
                            "price": 8.95,
                            "edition": 2
                        },
                        { 
                            "category": "fiction",
                            "author": "Evelyn Waugh",
                            "title": "Sword of Honour",
                            "price": 12.99,
                            "edition": 6
                        },
                        { 
                            "category": "fiction",
                            "author": "Herman Melville",
                            "title": "Moby Dick",
                            "isbn": "0-553-21311-3",
                            "price": 8.99,
                            "edition": 5
                        },
                        { 
                            "category": "fiction",
                            "author": "J. R. R. Tolkien",
                            "title": "The Lord of the Rings",
                            "isbn": "0-395-19395-8",
                            "price": 22.99,
                            "edition": 1
                        }
                        ],
                        "bicycle": {
                        "color": "red",
                        "price": 19.95
                        }
                    }
                }
                """


    Scenario: Validates value of specific string property
        Notice the value is surrounded by quotes to indicate is a string.

        Then the response json at $.store.book[0].author is equal to "Nigel Rees"


    Scenario: Validates value of specific integer property
        Notice integer values are not surrounded by quotes.

        Then the response json at $.store.book[2].edition is equal to 5


    Scenario: Validates value of specific double property
        Notice double values are not surrounded by quotes.
        
        Then the response json at $.store.book[3].price is equal to 22.99


    Scenario: Validates all values in specified range
        Then the response json at $.store.book[1:4].category is equal to "fiction"


    Scenario: Variables can be used in json path
        Then the response json at ${TITLE_PATH} is equal to "The Lord of the Rings"
            And the response json at $.store.book[${BOOK_INDEX}].title is equal to "Sword of Honour"
            And the response json at $.store.book[2].${TITLE} is equal to "Moby Dick"


    Scenario: Variables can be used in expected value
        Then the response json at $.store.book[1:4].category is equal to "${CATEGORY_FICTION}"

```