### PR TITLE
Adds support for defined schemas

### DIFF
--- a/behave_restful/_lang_imp/response_validator.py
+++ b/behave_restful/_lang_imp/response_validator.py
@@ -21,7 +21,16 @@ def response_json_matches(response, schema_str):
     """
     schema = json.loads(schema_str)
     json_body = response.json()
-    jsonschema.validate(json_body, schema)
+    _validate_with_schema(json_body, schema)
+
+
+def response_json_matches_defined_schema(context, schema_id):
+    """
+    """
+    schema_id = context.vars.resolve(schema_id)
+    schema = context.schemas.get(schema_id)
+    json_body = context.response.json()
+    _validate_with_schema(json_body, schema)
 
 
 def response_json_matches_at(response, json_path, expected_str):
@@ -44,5 +53,9 @@ def _get_values(json_body, json_path):
     results = jp.parse(json_path).find(json_body)
     if not results: fail('Match not found at <{path}> for <{body}>'.format(path=json_path, body=json_body))
     values = [result.value for result in results]
-    return values    
+    return values
+
+
+def _validate_with_schema(json_body, schema)  :
+    jsonschema.validate(json_body, schema)
 

--- a/behave_restful/about.py
+++ b/behave_restful/about.py
@@ -14,7 +14,7 @@ author_email = 'isaac_rodriguez@live.com'
 maintainer = 'Isaac Rodriguez'
 
 version = '0.1'
-release = '0.1.4'
+release = '0.1.5'
 
 classifiers = [
     'Development Status :: 1 - Planning',

--- a/behave_restful/lang/_then_steps.py
+++ b/behave_restful/lang/_then_steps.py
@@ -15,6 +15,11 @@ def step_impl(context):
     _validate.response_json_matches(context.response, schema)
 
 
+@then('the response json matches defined schema {schema_id}')
+def step_impl(context, schema_id):
+    _validate.response_json_matches_defined_schema(context, schema_id)
+
+
 @then('the response json at {json_path} is equal to {value_str}')
 def step_impl(context, json_path, value_str):
     json_path = context.vars.resolve(json_path)

--- a/features/definitions/br_test.py
+++ b/features/definitions/br_test.py
@@ -15,7 +15,8 @@ vars = {
     'TITLE': 'title',
     'CATEGORY_FICTION': "fiction",
     'PARAM_ID': 'id_number',
-    'PARAM_NAME': 'first_name'
+    'PARAM_NAME': 'first_name',
+    'TEST_SCHEMA_ID': 'TEST_SCHEMA'
 }
 
 def initialize_definition(context):

--- a/features/features_lang/then/the_response_json_matches_defined_schema.feature
+++ b/features/features_lang/then/the_response_json_matches_defined_schema.feature
@@ -1,0 +1,20 @@
+Feature: Step then the response json matches defined schema
+    Validates the functionality of the step "the response json matches defined schema"
+
+    Background: We use a response double from where the JSON payload is retrieved
+        Given a test response
+            And the response contains a json body like
+                """
+                {
+                    "id": 1,
+                    "name": "a name"
+                }
+                """
+
+
+    Scenario: Validates the response against the specified schema id
+        Then the response json matches defined schema TEST_SCHEMA
+
+
+    Scenario: Resolves the schema id to retrieve the defined schema
+        Then the response json matches defined schema ${TEST_SCHEMA_ID}

--- a/features/hooks/schema_initialization.py
+++ b/features/hooks/schema_initialization.py
@@ -1,0 +1,27 @@
+"""
+Initializes the defined schemas.
+"""
+
+
+SCHEMAS = {
+    'TEST_SCHEMA': {
+        "title": "SampleObject",
+        "type": "object",
+        "properties": {
+            "id": {"type": "number"},
+            "name": {"type": "string"}
+        },
+        "required": ["id", "name"]
+    }
+}
+
+SCHEMA_TESTING_FEATURES = {'step then the response json matches defined schema'}
+
+def before_feature(context, feature):
+    if feature.name.lower() in SCHEMA_TESTING_FEATURES:
+        context.schemas = SCHEMAS
+
+
+def after_feature(context, feature):
+     if feature.name.lower() in SCHEMA_TESTING_FEATURES:
+         context.schemas = None


### PR DESCRIPTION
Adds support for defined schemas within a dictionary like object, so the schema definition can be accessed through an ID; preventing hardcoded schemas in the feature file and enabling reusability.

The process requires the context to be initialized with a property schemas, which is set to a dictionary like object. The specified id will be passed to `context.schemas.get(id)` to retrieve the schema and responses will be validated against it.

It is recommended to initialize `context.schemas` in a `before_all()` or `before_feature()` hook.