### PR TITLE
bug fix: missing pkg-dep assertpy on pip install

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,3 +1,4 @@
+assertpy>=0.12
 behave>=1.2.5
 jsonpath-rw>=1.4.0
 jsonschema>=2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 -r dependencies.txt
-assertpy>=0.12
 bolt-ta>=0.2.10
 conttest>=0.0.8
 coverage>=4.1


### PR DESCRIPTION
When an end user uses 'pip install behave-restful'
to install the module, and then tries to use the module,
they will get an error for missing module assertpy.

The need to include assertpy as a depenedency comes from
behave_restful._lang_imp.response_validator.py,
which imports assertpy.

The reason assertpy is missing is that it has previously
been included by requirements.txt instead of depenedencies.txt.
Looking at setup.py, it appears that only dependencies.txt
gets included for the pip installable module,
and the remaining dependencies in requirements.txt are only
for doing dev on the behave-restful module itself.

So the fix was simple:

 - requirements.txt: removed assertpy
 - dependencies.txt added assertpy so that it will be included with pip
install