### PR TITLE
Example demos running end-to-end behave-restful tests on a Flask api

### DIFF
--- a/examples/flask_api/README.md
+++ b/examples/flask_api/README.md
@@ -1,0 +1,60 @@
+# Example: Test a Flask REST API End to End
+
+## Setup
+
+To work in a conda env, do:
+
+```bash
+conda create --name behave_restful_flask_api pip python=3.7 && \
+    source activate behave_restful_flask_api && \
+    pip install -r requirements.txt
+```
+
+## Running the Example
+
+The aim is to have a runnable task that starts our Flask server, and then once the server is running, executes our behave tests.
+
+In this example, we use [bolt](https://github.com/abantos/bolt/), which is a python task runner modelled after js grunt.
+
+With your conda env activated (or otherwise making sure all requirements are in your python env), do
+
+```bash
+# shell in the root of flask_api example
+bolt test-features
+```
+
+...if all goes well, this should
+- start up the Flask server
+- wait 2 seconds to make sure Flask started fully
+- execute behave
+
+...and you will see output like the below
+
+```
+ * Serving Flask app "api" (lazy loading)
+ * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
+Feature: Provides api info # features/provides_api_info.feature:1
+  Requests to the root of the api
+  provide infp about the api itself
+  Scenario: Get the api version                           features/provides_api_info.feature:6
+    Given a request url http://127.0.0.1:5000
+    When the request sends GET                           # "GET / HTTP/1.1" 200 -
+    Then the response status is OK                      
+    And the response json matches                        
+      """
+      {
+          "title": "APIInfoObject",
+          "type": "object",
+          "properties": {
+              "version": {"type": "string"}
+          },
+          "required": ["version"]
+      }
+      """
+    And the response json at $.version is equal to "1.0"
+
+1 feature passed, 0 failed, 0 skipped
+1 scenario passed, 0 failed, 0 skipped
+5 steps passed, 0 failed, 0 skipped, 0 undefined
+Took 0m0.010s
+```

--- a/examples/flask_api/api/__init__.py
+++ b/examples/flask_api/api/__init__.py
@@ -1,0 +1,14 @@
+from flask import Flask
+import json
+
+app = Flask(__name__)
+
+@app.route('/')
+def api_info():
+    """
+    requests to the root of this api
+    just return metadata about the api itself
+    """
+    return json.dumps({
+        "version": "1.0"
+    })

--- a/examples/flask_api/bolt_flask.py
+++ b/examples/flask_api/bolt_flask.py
@@ -1,0 +1,35 @@
+import subprocess
+import bolt.api as btapi
+
+class StartFlaskServiceTask(btapi.Task):
+    
+    def __init__(self):
+        super(StartFlaskServiceTask, self).__init__()
+        self.process = None
+
+    def tear_down(self):
+        if self.process:
+            self._terminate(self.process)
+            
+    def _configure(self):
+        self.startup_script = self.config.get('startup-script')
+        if not self.startup_script: raise StartupScriptNotSpecifiedError()
+
+    def _execute(self):
+        args = ['python', self.startup_script]
+        self.process = self._popen_script(args)
+
+    def _popen_script(self, args):
+        return subprocess.Popen(args)
+
+    def _terminate(self, process):
+        process.terminate()
+        
+        
+def register_tasks(registry):
+	registry.register_task('start-flask', StartFlaskServiceTask())
+        
+        
+class StartupScriptNotSpecifiedError(btapi.RequiredConfigurationError):
+    def __init__(self):
+        return super().__init__('startup-script')

--- a/examples/flask_api/boltfile.py
+++ b/examples/flask_api/boltfile.py
@@ -1,0 +1,25 @@
+import bolt
+import bolt_flask
+import behave_restful.bolt_behave_restful as bbr
+
+bolt.register_module_tasks(bolt_flask)
+bolt.register_module_tasks(bbr)
+
+# Bolt has a provided task sleep that is automatically registered
+
+config = {
+	'start-flask': {
+		'startup-script': 'run_api.py'
+	},
+	'sleep': {
+		'duration': 2
+	},
+	'behave-restful': {
+		'directory': 'features' # path to features folder
+		# 'definition': 'yourdefinition',	# if you are using definitions for different environments
+	}
+}
+
+# Register a task to invoke all that here:
+
+bolt.register_task('test-features', ['start-flask', 'sleep', 'behave-restful'])

--- a/examples/flask_api/features/environment.py
+++ b/examples/flask_api/features/environment.py
@@ -1,0 +1,45 @@
+# behave-restful's required hooks
+import os
+import behave_restful.app as br_app
+
+
+def before_all(context):
+    this_directory = os.path.abspath(os.path.dirname(__file__))
+    br_app.BehaveRestfulApp().initialize_context(context, this_directory)
+    context.hooks.invoke(br_app.BEFORE_ALL, context)
+
+
+def after_all(context):
+    context.hooks.invoke(br_app.AFTER_ALL, context)
+
+
+def before_feature(context, feature):
+    context.hooks.invoke(br_app.BEFORE_FEATURE, context, feature)
+
+
+def after_feature(context, feature):
+    context.hooks.invoke(br_app.AFTER_FEATURE, context, feature)
+
+
+def before_scenario(context, scenario):
+    context.hooks.invoke(br_app.BEFORE_SCENARIO, context, scenario)
+
+
+def after_scenario(context, scenario):
+    context.hooks.invoke(br_app.AFTER_SCENARIO, context, scenario)
+
+
+def before_step(context, step):
+    context.hooks.invoke(br_app.BEFORE_STEP, context, step)
+
+
+def after_step(context, step):
+    context.hooks.invoke(br_app.AFTER_STEP, context, step)
+
+
+def before_tag(context, tag):
+    context.hooks.invoke(br_app.BEFORE_TAG, context, tag)
+
+
+def after_tag(context, tag):
+    context.hooks.invoke(br_app.AFTER_TAG, context, tag)

--- a/examples/flask_api/features/provides_api_info.feature
+++ b/examples/flask_api/features/provides_api_info.feature
@@ -1,0 +1,22 @@
+Feature: Provides api info
+
+  Requests to the root of the api
+  provide infp about the api itself
+
+Scenario: Get the api version
+        Given a request url http://127.0.0.1:5000
+        When the request sends GET
+        Then the response status is OK
+            And the response json matches
+                """
+                {
+                    "title": "APIInfoObject",
+                    "type": "object",
+                    "properties": {
+                        "version": {"type": "string"}
+                    },
+                    "required": ["version"]
+                }
+                """
+            And the response json at $.version is equal to "1.0"
+            

--- a/examples/flask_api/features/steps/__init__.py
+++ b/examples/flask_api/features/steps/__init__.py
@@ -1,0 +1,3 @@
+# we need to include behave-restful's step defs
+# or they won't be available in .feature files
+from behave_restful.lang import *

--- a/examples/flask_api/requirements.txt
+++ b/examples/flask_api/requirements.txt
@@ -1,0 +1,5 @@
+assertpy
+behave
+behave-restful
+bolt-ta
+flask

--- a/examples/flask_api/run_api.py
+++ b/examples/flask_api/run_api.py
@@ -1,0 +1,2 @@
+from api import app
+app.run()


### PR DESCRIPTION
This example includes a version basic Flask api
(it does nothing but return version info for requests to '/'),
and shows how to set up a task to run the flask server
and then behave-restful feature tests against the flask server
using bolt.