### PR TITLE
Implements br-init command line tool

### DIFF
--- a/behave_restful/_project/definitions/sample.py
+++ b/behave_restful/_project/definitions/sample.py
@@ -1,0 +1,12 @@
+"""
+This module is loaded when 'sample' is passed as the definition to Behave Restful.
+The variables here defined can then be used for testing. Definitions are used
+to define variables with values matching for different testing environments.
+"""
+
+vars = {
+    'BASE_URL': 'https://api.github.com',
+}
+
+def initialize_definition(context):
+    context.vars.add_vars(vars)

--- a/behave_restful/_project/environment.py
+++ b/behave_restful/_project/environment.py
@@ -1,0 +1,45 @@
+import os
+
+import behave_restful.app as br_app
+
+
+def before_all(context):
+    this_directory = os.path.abspath(os.path.dirname(__file__))
+    br_app.BehaveRestfulApp().initialize_context(context, this_directory)
+    context.hooks.invoke(br_app.BEFORE_ALL, context)
+
+
+def after_all(context):
+    context.hooks.invoke(br_app.AFTER_ALL, context)
+
+
+def before_feature(context, feature):
+    context.hooks.invoke(br_app.BEFORE_FEATURE, context, feature)
+
+
+def after_feature(context, feature):
+    context.hooks.invoke(br_app.AFTER_FEATURE, context, feature)
+
+
+def before_scenario(context, scenario):
+    context.hooks.invoke(br_app.BEFORE_SCENARIO, context, scenario)
+
+
+def after_scenario(context, scenario):
+    context.hooks.invoke(br_app.AFTER_SCENARIO, context, scenario)
+
+
+def before_step(context, step):
+    context.hooks.invoke(br_app.BEFORE_STEP, context, step)
+
+
+def after_step(context, step):
+    context.hooks.invoke(br_app.AFTER_STEP, context, step)
+
+
+def before_tag(context, tag):
+    context.hooks.invoke(br_app.BEFORE_TAG, context, tag)
+
+
+def after_tag(context, tag):
+    context.hooks.invoke(br_app.AFTER_TAG, context, tag)

--- a/behave_restful/_project/hooks/sample_hook.py
+++ b/behave_restful/_project/hooks/sample_hook.py
@@ -1,0 +1,45 @@
+"""
+All python modules in this folder are loaded by Behave Restful and the
+implemented hooks are registered to be invoked at the correct time. You can
+uncomment the hook you need and implement it or create a new hooks file in this
+folder using this one as a base.
+"""
+
+# def before_all(context):
+#     pass
+
+
+# def after_all(context):
+#     pass
+    
+
+# def before_feature(context, feature):
+#     pass
+
+
+# def after_feature(context, feature):
+#     pass
+
+
+# def before_scenario(context, scenario):
+#     pass
+
+
+# def after_scenario(context, scenario):
+#     pass
+
+
+# def before_step(context, step):
+#     pass
+
+
+# def after_step(context, step):
+#     pass
+
+
+# def before_tag(context, tag):
+#     pass
+
+
+# def after_tag(context, tag):
+#     pass

--- a/behave_restful/_project/sample.feature
+++ b/behave_restful/_project/sample.feature
@@ -1,0 +1,13 @@
+Feature: Sample Feature
+    This is a sample feature that allows you to test that everything is working.
+    You can remove it once you start adding your own features, or you can use it
+    as a template for your projects.
+
+    Scenario: We send a request to the Github API base url
+        This scenario access the Github API base url to retrieve information
+        about the service.
+
+        Given a request url ${BASE_URL}
+        When the request sends GET
+        Then the response status is OK
+            And the response json at $.current_user_url is equal to "${BASE_URL}/user"

--- a/behave_restful/_project/steps/rest_steps.py
+++ b/behave_restful/_project/steps/rest_steps.py
@@ -1,0 +1,7 @@
+"""
+This module imports all the REST language implementation steps into the project
+so you can use them to write the tests. You can implement additional steps in
+this module, or better yet, create additional step files in this folder for 
+your custom steps.
+"""
+from behave_restful.lang import *

--- a/behave_restful/app.py
+++ b/behave_restful/app.py
@@ -99,7 +99,7 @@ class ProjectInitError(Exception):
     """
     """
     def __init__(self, reason):
-        super().__init__()
+        super(ProjectInitError, self).__init__()
         self.reason = reason
 
 

--- a/behave_restful/app.py
+++ b/behave_restful/app.py
@@ -4,6 +4,7 @@ execution context providing access to directories and other services to
 simplify testing.  
 """
 import os
+import shutil
 
 import requests
 
@@ -48,6 +49,59 @@ class BehaveRestfulApp(object):
         _hooks.EnvironmentHookInitializer().initialize(context)
 
 
-    
 
     
+class BrInitApp(object):
+    """
+    Application class for the br-init command that creates a new Behave Restful
+    project.
+    """
+    def __init__(self):
+        self.project_dir = os.path.join(os.getcwd(), 'features')
+        behave_restful_root = os.path.dirname(os.path.abspath(__file__))
+        self.src_dir = os.path.join(behave_restful_root, '_project')
+
+
+    def init_project(self, project_dir=None):
+        """
+        Creates a new project by copying the default template files to the
+        specified destination, or the features folder in the current working
+        directory.
+
+        The destination folder cannot exist before running this application.
+        """
+        self.project_dir = project_dir or self.project_dir
+        msg = 'Creating project at: {d}'.format(d=self.project_dir)
+        print(msg)
+        self._check_project_dir()
+        self._copy_project_files()
+
+
+    def _check_project_dir(self):
+        if self._exists(self.project_dir):
+            raise ProjectInitError('Target directory already exists')
+
+    
+    def _copy_project_files(self):
+        self._copy_tree(self.src_dir, self.project_dir)
+
+
+    def _exists(self, path):
+        return os.path.exists(path)
+
+
+    def _copy_tree(self, src, dst):
+        shutil.copytree(src, dst)
+
+
+
+class ProjectInitError(Exception):
+    """
+    """
+    def __init__(self, reason):
+        super().__init__()
+        self.reason = reason
+
+
+    def __repr__(self):
+        return 'ProjectInitError({r})'.format(r=self.reason)

--- a/behave_restful/bolt_behave_restful.py
+++ b/behave_restful/bolt_behave_restful.py
@@ -23,8 +23,6 @@ class RunBehaveRestfulTask(bolt_api.Task):
 
     def _configure(self):
         self.features_dir = self._require('directory')
-        if not self.features_dir:
-            raise FeaturesDirectoryNotSpecifiedError()
         if not self._exists(self.features_dir): 
             raise FeaturesDirectoryDoesNotExistError(self.features_dir)
         self.definition = self.config.get('definition')

--- a/behave_restful/cli.py
+++ b/behave_restful/cli.py
@@ -1,0 +1,19 @@
+"""
+Exposes functions to provide a command line interface to Behave Restful.
+"""
+import sys
+
+import behave_restful.app as app
+
+def behave_restful_init():
+    try:
+        target_dir = sys.argv[1] if len(sys.argv) > 1 else None
+        application = app.BrInitApp()
+        application.init_project(target_dir)
+    except app.ProjectInitError as err:
+        print(err.reason)
+        sys.exit(2)
+    except Exception as err:
+        msg = 'Error creating project {e}'.format(e=err)
+        print(msg)
+        sys.exit(1)

--- a/boltfile.py
+++ b/boltfile.py
@@ -115,7 +115,7 @@ config = {
         'directory': FEATURES_DIR,
         'definition': 'br_test',
         'options': {
-            'format': 'progress2'
+            'format': 'progress2',
         },
         'ci': {
             'options': {

--- a/features/hooks/project_creation.py
+++ b/features/hooks/project_creation.py
@@ -1,0 +1,23 @@
+"""
+Contains hooks to test project creation
+"""
+import os
+import shutil
+
+
+def before_feature(context, feature):
+    if feature.name == 'Project Creation':
+        context.initial_working_directory = os.getcwd()
+        context.sandbox_dir = os.path.join(context.initial_working_directory, 'sandbox')
+        context.project_src_dir = os.path.join(context.test_dir, '..', 'behave_restful', '_project')
+        existent_dir = os.path.join(context.sandbox_dir, 'existent')
+        os.makedirs(existent_dir)
+        os.chdir(context.sandbox_dir)
+        
+
+
+def after_feature(context, feature):
+    if feature.name == 'Project Creation':
+        os.chdir(context.initial_working_directory)
+        shutil.rmtree(context.sandbox_dir)
+

--- a/features/project_creation.feature
+++ b/features/project_creation.feature
@@ -1,0 +1,30 @@
+Feature: Project Creation
+    This suite verify the correct implementation of the br-init app to create a
+    new Behave Restful Project.
+
+
+    Scenario: Creates project in default features folder
+        The application creates the project in a default features folder when
+        no directory is specifies as parameter.
+
+        Given br-init is run with no parameters
+        When the application executes
+        Then the project is created at features folder
+
+
+    Scenario: Creates project in specified location
+        The application creates the project at the location specifies as
+        parameter.
+
+        Given br-init is run with project_dir
+        When the application executes
+        Then the project is created at project_dir folder
+
+
+    Scenario: An exception is raised if specified folder exists
+        The user specifies a folder that already exists, in which case the
+        application raises an exception as exits with an error code
+
+        Given br-init is run with existent
+        When the application executes
+        Then an exception is raised

--- a/features/steps/project_creation_steps.py
+++ b/features/steps/project_creation_steps.py
@@ -1,0 +1,33 @@
+import filecmp
+import os
+
+from assertpy import assert_that, fail
+from behave import *
+
+import behave_restful.app as app
+
+@given('br-init is run with {location}')
+def step_impl(context, location):
+    context.location_param = None if location == 'no parameters' else location
+    project_folder = context.location_param or 'features'
+    context.project_created_dir = os.path.join(os.getcwd(), project_folder)
+
+
+@when('the application executes')
+def step_impl(context):
+    try:
+        app.BrInitApp().init_project(context.location_param)
+    except Exception as err:
+        context.exception_raised = err
+
+
+@then('the project is created at {folder} folder')
+def step_impl(context, folder):
+    result = filecmp.dircmp(context.project_src_dir, context.project_created_dir)
+    assert_that(result.diff_files).is_empty()
+
+
+@then('an exception is raised')
+def step_impl(context):
+    if not 'exception_raised' in context:
+        fail('Exception not raised')

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,15 @@ def _read_dependencies():
 
 packages = find_packages()
 requirements = _read_dependencies()
+entry_points = {
+    'console_scripts': [
+        'br-init = behave_restful.cli:behave_restful_init'
+    ]
+}
 
+package_data = {
+    'behave_restful': ['./_project/**/*']
+}
 
 setup(
     name=about.project,
@@ -32,5 +40,7 @@ setup(
     keywords=about.keywords,
     classifiers=about.classifiers,
     packages=packages,
-    install_requires=requirements
+    install_requires=requirements,
+    entry_points=entry_points,
+    package_data=package_data
 )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -39,5 +39,61 @@ class ContextDouble(object):
 
 
 
+class TestBrInitApp(unittest.TestCase):
+
+    def setUp(self):
+        self.app = BrInitAppSpy()
+        self.default_directory = os.path.join(os.getcwd(), 'features')
+        self.another_directory = os.path.join(os.getcwd(), 'another')
+        self.project_source = os.path.join(os.getcwd(), 'behave_restful', '_project')
+
+    def test_initializes_directory_to_features_in_current_folder(self):
+        assert_that(self.app.project_dir).is_equal_to(self.default_directory)
+
+
+    def test_replaces_project_directory_with_specified_directory(self):
+        self.app.init_project(self.another_directory)
+        assert_that(self.app.project_dir).is_equal_to(self.another_directory)
+
+
+    def test_keeps_default_project_directory_if_none_specified(self):
+        self.app.init_project()
+        assert_that(self.app.project_dir).is_equal_to(self.default_directory)
+
+
+    def test_initializes_the_project_source_files_location(self):
+        assert_that(self.app.src_dir).is_equal_to(self.project_source)
+
+
+    def test_raises_if_directory_already_exists(self):
+        self.app.return_destination_exists = True
+        assert_that(self.app.init_project).raises(br_app.ProjectInitError).when_called_with()
+
+
+    def test_copies_project_files_to_target_directory(self):
+        self.app.init_project()
+        assert_that(self.app.specified_src, self.app.src_dir)
+        assert_that(self.app.specified_dst, self.app.project_dir)
+
+class BrInitAppSpy(br_app.BrInitApp):
+    def __init__(self):
+        super().__init__()
+        self.return_destination_exists = False
+        self.specified_src = None
+        self.specified_dst = None
+
+
+    def _exists(self, path):
+        return self.return_destination_exists
+
+
+    def _copy_tree(self, src, dst):
+        self.specified_src = src
+        self.specified_dst = dst
+
+
+
+
+
 if __name__=="__main__":
     unittest.main()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -77,7 +77,7 @@ class TestBrInitApp(unittest.TestCase):
 
 class BrInitAppSpy(br_app.BrInitApp):
     def __init__(self):
-        super().__init__()
+        super(BrInitAppSpy, self).__init__()
         self.return_destination_exists = False
         self.specified_src = None
         self.specified_dst = None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -67,7 +67,9 @@ class TestBrInitApp(unittest.TestCase):
 
     def test_raises_if_directory_already_exists(self):
         self.app.return_destination_exists = True
-        assert_that(self.app.init_project).raises(br_app.ProjectInitError).when_called_with()
+        with self.assertRaises(br_app.ProjectInitError):
+            self.app.init_project()
+        # assert_that(self.app.init_project).raises(br_app.ProjectInitError).when_called_with()
 
 
     def test_copies_project_files_to_target_directory(self):


### PR DESCRIPTION
Implements an entry point `br-init` that creates a new behave restful project with some sample files.

These changes allow users to run `br-init` to create a new project that is functional and can be used as starting point for their test projects. The project contains all the necessary files to use behave restful, as well as, sample files for hooks, definitions, and steps.