### PR TITLE
Migrated to jsonpath module

### DIFF
--- a/behave_restful/_lang_imp/response_validator.py
+++ b/behave_restful/_lang_imp/response_validator.py
@@ -3,7 +3,7 @@
 import json
 
 from assertpy import assert_that, fail
-import jsonpath_rw as jp
+from jsonpath import jsonpath
 import jsonschema
 
 from behave_restful.xpy import HTTPStatus
@@ -112,10 +112,9 @@ def _as_numeric_status(status):
 
 
 def _get_values(json_body, json_path):
-    results = jp.parse(json_path).find(json_body)
+    results = jsonpath(json_body, json_path)
     if not results: fail('Match not found at <{path}> for <{body}>'.format(path=json_path, body=json_body))
-    values = [result.value for result in results]
-    return values
+    return results
 
 
 def _validate_with_schema(json_body, schema)  :

--- a/behave_restful/about.py
+++ b/behave_restful/about.py
@@ -3,8 +3,8 @@ Provides properties with information about ``behave_restful``.
 """
 
 project = 'behave-restful'
-version = '0.1'
-release = '0.1.12'
+version = '0.2'
+release = '0.2.0'
 description = 'Implements Gherking language for REST services.'
 copyright = '2017 Abantos'
 author = 'Isaac Rodriguez'

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,5 +1,5 @@
 assertpy>=0.12
 behave>=1.2.5
-jsonpath-rw>=1.4.0
+jsonpath>=0.82
 jsonschema>=2.6.0
 requests>=2.18.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -r dependencies.txt
-bolt-ta>=0.2.10
+bolt-ta>=0.3.2
 conttest>=0.0.8
 coverage>=4.1
 m2r>=0.2.1


### PR DESCRIPTION
This change migrates the JsonPath validation to use the `jsonpath` module instead of `jsonpath-rw` because supports more features than the spec. The documentation is lacking, but it seems that supports the standard as described in the [Stephan Gossner website](https://goessner.net/articles/JsonPath/).

Because the change in requirements, it is recommended to create new virtual environments for your projects using behave-restful.

In the development environment, I updated the version used for `bolt-ta` to fix recent changes to `pip`.