### PR TITLE
Adds support to validate responses from schemas in an openapi document

### DIFF
--- a/behave_restful/_schemas.py
+++ b/behave_restful/_schemas.py
@@ -1,0 +1,75 @@
+"""
+"""
+import json
+import os.path
+
+import jsonref
+import yaml
+
+def add_json_schemas(schemas, context):
+    """
+    """
+    if not hasattr(context, 'schemas') or not context.schemas:
+        context.schemas = {}
+    context.schemas.update(schemas)
+
+
+def add_openapi_schemas(openapi_filename, context):
+    abs_path = os.path.abspath(openapi_filename)
+    root, filename = os.path.split(openapi_filename)
+    loader = ReferenceFileLoader(root)
+    reader = OpenApiReader(filename, loader)
+    add_json_schemas(reader.schemas, context)
+
+
+class OpenApiReader:
+    def __init__(self, filename, loader):
+        self._filename = filename
+        self._loader = loader
+        self._content = None
+
+
+    @property
+    def content(self):
+        if not self._content:
+            self._content = self._load()
+        return self._content
+
+
+    @property
+    def schemas(self):
+        return self.content.get('components').get('schemas')
+
+
+    def _load(self):
+        content = self._loader(self._filename)
+        content = jsonref.JsonRef.replace_refs(content, loader=self._loader)
+        return content
+
+
+
+
+
+class ReferenceFileLoader:
+    def __init__(self, root_dir):
+        self.root_dir = root_dir
+
+        
+    def __call__(self, ref_file):
+        full_name = os.path.join(self.root_dir, ref_file)
+        reader = get_reader(ref_file)
+        return self._load(reader, full_name)
+
+
+    def _load(self, reader, filename):
+        with open(filename) as fin:
+            return reader.load(fin)
+
+
+YAML_EXT = '.yaml'
+
+def get_reader(filename):
+    name, ext = os.path.splitext(filename)
+    if ext == YAML_EXT:
+        return yaml
+    return json

--- a/behave_restful/about.py
+++ b/behave_restful/about.py
@@ -4,7 +4,7 @@ Provides properties with information about ``behave_restful``.
 
 project = 'behave-restful'
 version = '0.3'
-release = f'{version}.0'
+release = '{version}.0'.format(version=version)
 description = 'Implements Gherking language for REST services.'
 copyright = '2017 Abantos'
 author = 'Isaac Rodriguez'

--- a/behave_restful/about.py
+++ b/behave_restful/about.py
@@ -3,8 +3,8 @@ Provides properties with information about ``behave_restful``.
 """
 
 project = 'behave-restful'
-version = '0.2'
-release = '0.2.0'
+version = '0.3'
+release = f'{version}.0'
 description = 'Implements Gherking language for REST services.'
 copyright = '2017 Abantos'
 author = 'Isaac Rodriguez'
@@ -19,14 +19,11 @@ classifiers = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
-    'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Topic :: Internet :: WWW/HTTP',
     'Topic :: Software Development :: Testing :: Acceptance',
     'Topic :: Software Development :: Testing :: BDD',

--- a/behave_restful/tools.py
+++ b/behave_restful/tools.py
@@ -1,0 +1,3 @@
+"""
+"""
+from behave_restful._schemas import add_json_schemas, add_openapi_schemas

--- a/data/openapi/models/artists.json
+++ b/data/openapi/models/artists.json
@@ -1,0 +1,15 @@
+{
+    "components": {
+      "schemas": {
+        "Artist": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "example": "Dire Straits"
+            }
+          }
+        }
+      }
+    }
+  }

--- a/data/openapi/models/artists.yaml
+++ b/data/openapi/models/artists.yaml
@@ -1,0 +1,8 @@
+components:
+  schemas:
+    Artist:
+      type: object
+      properties:
+        name:
+          type: string
+          example: Dire Straits

--- a/data/openapi/openapi.json
+++ b/data/openapi/openapi.json
@@ -1,0 +1,95 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "YAML Test Service Documentation",
+      "description": "YAML file to test schema initialization through OpenAPI documents.",
+      "version": "1.0",
+      "contact": {
+        "name": "Abantos"
+      }
+    },
+    "servers": [
+      {
+        "url": "http://localhost:8080",
+        "description": "Local server"
+      }
+    ],
+    "tags": [
+      {
+        "name": "songs",
+        "description": "Song management endpoints."
+      }
+    ],
+    "paths": {
+      "/songs": {
+        "get": {
+          "tags": [
+            "songs"
+          ],
+          "summary": "Get songs collections.",
+          "description": "Get the collection of songs stored in the service.",
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SongCollection"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "NewSong": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "example": "Telegraph Road"
+            },
+            "artist": {
+              "$ref": "models/artists.json#/components/schemas/Artist"
+            }
+          },
+          "required": [
+            "title"
+          ]
+        },
+        "Song": {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/NewSong"
+            }
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "example": "123456"
+            }
+          },
+          "required": [
+            "id",
+            "title",
+            "artist"
+          ]
+        },
+        "SongCollection": {
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Song"
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/data/openapi/openapi.yaml
+++ b/data/openapi/openapi.yaml
@@ -1,0 +1,68 @@
+openapi: 3.0.1
+
+info:
+  title: YAML Test Service Documentation
+  description:  YAML file to test schema initialization through OpenAPI documents.
+  version: "1.0"
+  contact:
+    name: Abantos
+
+servers:
+  - url: http://localhost:8080
+    description: Local server
+
+tags:
+  - name: songs
+    description: Song management endpoints.
+  
+
+paths:
+  /songs:
+    get:
+      tags:
+        - songs
+      summary: Get songs collections.
+      description: Get the collection of songs stored in the service.
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SongCollection'
+
+components:
+  schemas:
+    NewSong:
+      type: object
+      properties:
+        title:
+          type: string
+          example: Telegraph Road
+        artist:
+          $ref: 'models/artists.yaml#/components/schemas/Artist'
+          
+      required:
+        - title
+    Song:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/NewSong'
+      properties:
+        id:
+          type: string
+          example:  "123456"
+      required:
+        - id
+        - title
+        - artist
+    SongCollection:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Song'
+        
+
+

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,5 +1,7 @@
-assertpy>=0.12
-behave>=1.2.5
-jsonpath>=0.82
-jsonschema>=2.6.0
-requests>=2.18.4
+assertpy
+behave
+jsonpath
+jsonref
+jsonschema
+PyYaml
+requests

--- a/features/definitions/br_test.py
+++ b/features/definitions/br_test.py
@@ -27,3 +27,4 @@ vars = {
 
 def initialize_definition(context):
     context.vars.add_vars(vars)
+    context.vars.add('WORKING_DIR', context.working_dir)

--- a/features/hooks/schema_initialization.py
+++ b/features/hooks/schema_initialization.py
@@ -1,7 +1,7 @@
 """
 Initializes the defined schemas.
 """
-
+import behave_restful.tools as brt
 
 SCHEMAS = {
     'TEST_SCHEMA': {
@@ -19,7 +19,7 @@ SCHEMA_TESTING_FEATURES = {'step then the response json matches defined schema'}
 
 def before_feature(context, feature):
     if feature.name.lower() in SCHEMA_TESTING_FEATURES:
-        context.schemas = SCHEMAS
+        brt.add_json_schemas(SCHEMAS, context)
 
 
 def after_feature(context, feature):

--- a/features/openapi_schemas.feature
+++ b/features/openapi_schemas.feature
@@ -1,0 +1,43 @@
+Feature: Schema Validation from OpenAPI Schemas
+    This feature allows to validate responses using the schemas defined in an
+    OpenAPI document.
+
+
+    Scenario: Can validate a response using a JSON based OpenAPI file
+        Given an openapi file ${WORKING_DIR}/data/openapi/openapi.json
+            And a test response
+            And the response contains a json body like
+                """
+                {
+                    "items": [
+                        {
+                            "id": "45321",
+                            "title": "Sultans of Swing",
+                            "artist": {
+                                "name": "Dire Straits"
+                            }
+                        }
+                    ]
+                }
+                """
+        Then the response json matches defined schema SongCollection
+
+
+    Scenario: Can validate a response using a YAML based OpenAPI file
+        Given an openapi file ${WORKING_DIR}/data/openapi/openapi.yaml
+            And a test response
+            And the response contains a json body like
+                """
+                {
+                    "items": [
+                        {
+                            "id": "45321",
+                            "title": "Sultans of Swing",
+                            "artist": {
+                                "name": "Dire Straits"
+                            }
+                        }
+                    ]
+                }
+                """
+        Then the response json matches defined schema SongCollection

--- a/features/steps/openapi_steps.py
+++ b/features/steps/openapi_steps.py
@@ -1,0 +1,8 @@
+from behave import *
+
+import behave_restful.tools as brt
+
+@given('an openapi file {filename}')
+def step_impl(context, filename):
+    filename = context.vars.resolve(filename)
+    brt.add_openapi_schemas(filename, context)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,259 @@
+import io
+import json
+import os.path
+import unittest
+
+import yaml
+import jsonpath as jp
+
+from assertpy import assert_that
+
+import behave_restful._schemas as brs
+
+
+class TestAddJsonSchemas(unittest.TestCase):
+
+    def setUp(self):
+        self.context = ContextDouble()
+        self.schemas = {
+            'person': {
+                'type': 'object',
+                'properties': {
+                    'name': {'type': 'string'}
+                }
+            }
+        }
+        brs.add_json_schemas(self.schemas, self.context)
+
+
+    def test_sets_specified_schemas_in_context_object(self):
+        
+        assert_that(self.context.schemas).is_equal_to(self.schemas)
+
+
+    def test_aggregates_schemas_as_they_are_specified(self):
+        aggregate_schema = {
+            'pet': {
+                'type': 'object',
+                'properties': {
+                    'nickname': {'type': 'string'}
+                }
+            }
+        }
+        brs.add_json_schemas(aggregate_schema, self.context)
+        assert_that(self.context.schemas).contains_key('person')
+        assert_that(self.context.schemas).contains_key('pet')
+
+
+
+class TestOpenApiReader(unittest.TestCase):
+
+    def setUp(self):
+        self.root = os.path.abspath(os.path.dirname(__file__))
+        self.filename = 'openapi.json'
+        self.loader = ReferenceFileLoaderSpy(self.root)
+        self.reader = brs.OpenApiReader(self.filename, self.loader)
+
+
+    def test_returns_file_content(self):
+        actual_value = self.get_from(self.reader.content, '$.openapi')
+        assert_that(actual_value).is_equal_to('3.0.1')
+
+
+    def test_returns_file_schemas(self):
+        actual_value = self.get_from(self.reader.schemas, '$.NewSong.type')
+        assert_that(actual_value).is_equal_to('object')
+
+
+    def test_resolves_references(self):
+        actual_value = self.get_from(self.reader.schemas, '$.NewSong.properties.artist.type')
+        assert_that(actual_value).is_equal_to('object')
+
+
+    def get_from(self, content, jpath):
+        values = jp.jsonpath(content, jpath)
+        return values[0]
+
+
+
+        
+
+
+
+class TestReferenceFileLoader(unittest.TestCase):
+    
+    def setUp(self):
+        self.root = os.path.abspath(os.path.dirname(__file__))
+        self.loader = ReferenceFileLoaderSpy(self.root)
+
+
+    def test_loads_specified_file_with_correct_reader(self):
+        filename = 'openapi.yaml'
+        self.loader(filename)
+        assert_that(self.loader.specified_reader).is_same_as(yaml)
+
+
+    def test_loads_absolute_path_to_specified_file_name(self):
+        filename = 'openapi.json'
+        expected_file = os.path.join(self.root, filename)
+        self.loader(filename)
+        assert_that(self.loader.specified_file).is_equal_to(expected_file)
+        
+
+
+class TestGetReader(unittest.TestCase):
+
+    def test_returns_json_module_if_file_is_json(self):
+        self.given('file.json').expect(json)
+
+
+    def test_returns_yaml_module_if_file_is_yaml(self):
+        self.given('file.yaml').expect(yaml)
+
+
+    def given(self, filename):
+        self.filename = filename
+        return self
+
+    def expect(self, expected):
+        actual = brs.get_reader(self.filename)
+        assert_that(actual).is_same_as(expected)
+        return self
+
+
+
+class ReferenceFileLoaderSpy(brs.ReferenceFileLoader):
+
+    def _load(self, reader, filename):
+        self.specified_reader = reader
+        self.specified_file = filename
+        if 'openapi' in filename:
+            return FILE_CONTENT
+        else:
+            return REFERENCE_FILE_CONTENT
+
+
+
+
+class ContextDouble:
+    def __init__(self):
+        self.schemas = None
+
+
+FILE_CONTENT = {
+    "openapi": "3.0.1",
+    "info": {
+      "title": "YAML Test Service Documentation",
+      "description": "YAML file to test schema initialization through OpenAPI documents.",
+      "version": "1.0",
+      "contact": {
+        "name": "Abantos"
+      }
+    },
+    "servers": [
+      {
+        "url": "http://localhost:8080",
+        "description": "Local server"
+      }
+    ],
+    "tags": [
+      {
+        "name": "songs",
+        "description": "Song management endpoints."
+      }
+    ],
+    "paths": {
+      "/songs": {
+        "get": {
+          "tags": [
+            "songs"
+          ],
+          "summary": "Get songs collections.",
+          "description": "Get the collection of songs stored in the service.",
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SongCollection"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "NewSong": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "example": "Telegraph Road"
+            },
+            "artist": {
+              "$ref": "models/artists.json#/components/schemas/Artist"
+            }
+          },
+          "required": [
+            "title"
+          ]
+        },
+        "Song": {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/NewSong"
+            }
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "example": "123456"
+            }
+          },
+          "required": [
+            "id",
+            "title",
+            "artist"
+          ]
+        },
+        "SongCollection": {
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Song"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+REFERENCE_FILE_CONTENT = {
+    "components": {
+      "schemas": {
+        "Artist": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "example": "Dire Straits"
+            }
+          }
+        }
+      }
+    }
+  }
+        
+
+
+
+if __name__=="__main__":
+    unittest.main()


### PR DESCRIPTION
This change provides a couple of new functions in `behave_restful.tools`:
* `add_json_schemas(schemas, context)`: Adds the specified schemas to the context, so they can be used for validation.
* `add_openapi_schemas(openapi_filename, context)`: Adds the schemas declared in `openapi_filename`, so they can be used for validation.

The openapi file can be a JSON or YAML file using OpenAPI 3.0 or higher. The implementation has full support for JsonRef, so that the declaration of the schemas can exist in multiple files using the appropriate JsonRef syntax.
