### PR TITLE
FIX: Fixes infinite loop resolving variables when missing dollar sign

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install wheel
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Run Tests
       run: |

--- a/.github/workflows/verify-python-library.yml
+++ b/.github/workflows/verify-python-library.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Verify Python Library
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v3

--- a/behave_restful/_definitions.py
+++ b/behave_restful/_definitions.py
@@ -169,14 +169,19 @@ class VarsManager(object):
 
 
     def _find_var_name_in(self, to_resolve):
-        var_starts = to_resolve.find(VAR_PREFIX) + len(VAR_PREFIX)
-        var_ends = to_resolve.find(VAR_SUFFIX, var_starts)
-        return to_resolve[var_starts:var_ends]
+        prefix_location = to_resolve.find(VAR_PREFIX)
+        if self._prefix_found(prefix_location):
+            var_starts = prefix_location + len(VAR_PREFIX)
+            var_ends = to_resolve.find(VAR_SUFFIX, var_starts)
+            return to_resolve[var_starts:var_ends]
 
 
     def _replace_with(self, to_resolve, var_name, value):
         token = ''.join([VAR_PREFIX, var_name, VAR_SUFFIX])
         return to_resolve.replace(token, str(value))
+
+    def _prefix_found(self, location):
+        return location >= 0
 
 
 

--- a/behave_restful/_schemas.py
+++ b/behave_restful/_schemas.py
@@ -71,5 +71,13 @@ YAML_EXT = '.yaml'
 def get_reader(filename):
     name, ext = os.path.splitext(filename)
     if ext == YAML_EXT:
-        return yaml
+        return yaml_reader
     return json
+
+
+class _YamlReader:
+
+    def load(self, fin):
+        return yaml.load(fin, Loader=yaml.Loader)
+
+yaml_reader = _YamlReader()

--- a/behave_restful/about.py
+++ b/behave_restful/about.py
@@ -20,8 +20,6 @@ classifiers = [
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',

--- a/boltfile.py
+++ b/boltfile.py
@@ -126,6 +126,7 @@ config = {
         },
         'ci': {
             'options': {
+                'format': 'progress2',
                 'tags': [
                     ['~@disabled'], 
                     ['~@wip']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,7 +45,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'm2r'
+    'm2r2'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 -r dependencies.txt
-bolt-ta>=0.3.2
-conttest>=0.0.8
-coverage>=4.1
-m2r2>=0.2.1
-nose>=1.3.7
-pylint>=1.7.4
-sphinx==2.4.4
-sphinx-rtd-theme>=0.5.0
+bolt-ta
+conttest
+coverage
+m2r2
+nose
+pylint
+sphinx
+sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 bolt-ta>=0.3.2
 conttest>=0.0.8
 coverage>=4.1
-m2r>=0.2.1
+m2r2>=0.2.1
 nose>=1.3.7
 pylint>=1.7.4
 sphinx==2.4.4

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -189,7 +189,13 @@ class TestVarsManager(unittest.TestCase):
     def test_resolves_jsonpath_filter_values_correctly(self):
         resolution_string = '$.store.book[?(@.title=="${STRING_VAR}")]'
         expected_result = '$.store.book[?(@.title=="the string value")]'
+        self.assert_resolved(resolution_string).is_equal_to(expected_result)
 
+
+    def test_missing_dollar_sign_from_variable_returns_same_string(self):
+        mistyped_var = '{NO_DOLLAR}'
+        self.manager.add('NO_DOLLAR', 'no dollar')
+        self.assert_resolved(mistyped_var).is_equal_to(mistyped_var)
 
 
     def assert_var(self, var_name):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -75,11 +75,6 @@ class TestOpenApiReader(unittest.TestCase):
         return values[0]
 
 
-
-        
-
-
-
 class TestReferenceFileLoader(unittest.TestCase):
     
     def setUp(self):
@@ -90,7 +85,7 @@ class TestReferenceFileLoader(unittest.TestCase):
     def test_loads_specified_file_with_correct_reader(self):
         filename = 'openapi.yaml'
         self.loader(filename)
-        assert_that(self.loader.specified_reader).is_same_as(yaml)
+        assert_that(self.loader.specified_reader).is_same_as(brs.yaml_reader)
 
 
     def test_loads_absolute_path_to_specified_file_name(self):
@@ -108,7 +103,7 @@ class TestGetReader(unittest.TestCase):
 
 
     def test_returns_yaml_module_if_file_is_yaml(self):
-        self.given('file.yaml').expect(yaml)
+        self.given('file.yaml').expect(brs.yaml_reader)
 
 
     def given(self, filename):


### PR DESCRIPTION
The problem was caused when using an opening curly brace at the beginning of a string that was being resolved for embedded variables: "{something} and something else". The problem is also described on Issue #68 which this change should fix.
#68 
Resolving variables searches the string for the prefix using `str.find()`, which returns -1 when the prefix is not found. I wasn't checking the return value (not really sure why, but evidently I didn't even thing about that scenario because I didn't have a test), so this will cause the process to extract the string between curly braces ({something}). If this string matched a defined variable, the process will keep trying to resolve the string, which will find the same thing and enter an infinite loop.

The fix is to check the result of `str.find()` and only resolve the string if the prefix is found (return value >= 0)

Fixes issue #68 