### PR TITLE
Feat/add request form data payload that allow client to send files

### DIFF
--- a/behave_restful/_lang_imp/request_builder.py
+++ b/behave_restful/_lang_imp/request_builder.py
@@ -29,3 +29,17 @@ def set_request_headers(context, headers):
     resolve = context.vars.resolve
     resolved_headers = {resolve(header['param']): resolve(header['value']) for header in headers}
     context.request_headers = resolved_headers
+
+def set_form_data(context, table):
+    """
+    """
+    resolve = context.vars.resolve
+    data = {}
+    files = {}
+    for row in table:
+        name = resolve(row["param"])
+        value = resolve(row["value"])
+        if row["type"] == "file": files[name] = value
+        else: data[name] = value
+    context.request_form_data = data
+    context.request_files = files

--- a/behave_restful/_lang_imp/request_builder.py
+++ b/behave_restful/_lang_imp/request_builder.py
@@ -30,16 +30,16 @@ def set_request_headers(context, headers):
     resolved_headers = {resolve(header['param']): resolve(header['value']) for header in headers}
     context.request_headers = resolved_headers
 
-def set_form_data(context, table):
+def set_form_data_payload(context, table):
     """
     """
     resolve = context.vars.resolve
     data = {}
     files = {}
     for row in table:
-        name = resolve(row["param"])
+        name = resolve(row["key"])
         value = resolve(row["value"])
         if row["type"] == "file": files[name] = value
         else: data[name] = value
-    context.request_form_data = data
+    context.request_form_data_payload = data
     context.request_files = files

--- a/behave_restful/_lang_imp/request_invoker.py
+++ b/behave_restful/_lang_imp/request_invoker.py
@@ -56,7 +56,7 @@ def _send_with_body(context, method):
                 context.request_url,
                 headers=headers,
                 params=params,
-                data=getattr(context, 'request_form_data', None),
+                data=getattr(context, 'request_form_data_payload', None),
                 files=_open_request_files(context, stack),
             )
     else:

--- a/behave_restful/_lang_imp/request_invoker.py
+++ b/behave_restful/_lang_imp/request_invoker.py
@@ -1,5 +1,9 @@
 """
 """
+import mimetypes
+from contextlib import ExitStack
+from pathlib import Path
+
 
 def send_get(context):
     """
@@ -16,40 +20,19 @@ def send_get(context):
 def send_post(context):
     """
     """
-    headers = _get_request_headers(context)
-    params = _get_params(context)
-    context.response = context.session.post(
-        context.request_url,
-        headers=headers,
-        params=params,
-        json=context.request_json_payload
-    )
+    _send_with_body(context, context.session.post)
 
 
 def send_put(context):
     """
     """
-    headers = _get_request_headers(context)
-    params = _get_params(context)
-    context.response = context.session.put(
-        context.request_url,
-        headers=headers,
-        params=params,
-        json=context.request_json_payload
-    )
+    _send_with_body(context, context.session.put)
 
 
 def send_patch(context):
     """
     """
-    headers = _get_request_headers(context)
-    params = _get_params(context)
-    context.response = context.session.patch(
-        context.request_url,
-        headers=headers,
-        params=params,
-        json=context.request_json_payload
-    )
+    _send_with_body(context, context.session.patch)
 
 
 def send_delete(context):
@@ -63,6 +46,35 @@ def send_delete(context):
         params=params
     )
 
+
+def _send_with_body(context, method):
+    headers = _get_request_headers(context)
+    params = _get_params(context)
+    if hasattr(context, 'request_files'):
+        with ExitStack() as stack:
+            context.response = method(
+                context.request_url,
+                headers=headers,
+                params=params,
+                data=getattr(context, 'request_form_data', None),
+                files=_open_request_files(context, stack),
+            )
+    else:
+        context.response = method(
+            context.request_url,
+            headers=headers,
+            params=params,
+            json=context.request_json_payload,
+        )
+
+
+def _open_request_files(context, stack):
+    files = {}
+    for field, path in context.request_files.items():
+        file_object = stack.enter_context(open(path, 'rb'))
+        content_type, _ = mimetypes.guess_type(path)
+        files[field] = (Path(path).name, file_object, content_type or 'application/octet-stream')
+    return files
 
 
 def _get_params(context):

--- a/behave_restful/lang/_given_steps.py
+++ b/behave_restful/lang/_given_steps.py
@@ -22,3 +22,8 @@ def step_impl(context):
 @given('request parameters')
 def step_impl(context):
     _builder.set_request_params(context, context.table)
+
+
+@given("request form-data")
+def step_impl(context):
+    _builder.set_form_data(context, context.table)

--- a/behave_restful/lang/_given_steps.py
+++ b/behave_restful/lang/_given_steps.py
@@ -24,6 +24,6 @@ def step_impl(context):
     _builder.set_request_params(context, context.table)
 
 
-@given("request form-data")
+@given("a request form-data payload")
 def step_impl(context):
-    _builder.set_form_data(context, context.table)
+    _builder.set_form_data_payload(context, context.table)

--- a/features/features_lang/given/a_request_form_data_payload.feature
+++ b/features/features_lang/given/a_request_form_data_payload.feature
@@ -4,7 +4,7 @@ Feature: Step given a request form-data payload
 
     Scenario: Sets the specified form-data payload in the context
         Given a request form-data payload
-            | key      | value                    | type |
+            | key        | value                    | type |
             | timesheet  | features/files/test.csv  | file |
             | projectId  | 123                      | text |
         Then the context contains request form-data file timesheet with value set to features/files/test.csv

--- a/features/features_lang/given/a_request_form_data_payload.feature
+++ b/features/features_lang/given/a_request_form_data_payload.feature
@@ -8,4 +8,4 @@ Feature: Step given a request form-data payload
             | timesheet  | features/files/test.csv  | file |
             | projectId  | 123                      | text |
         Then the context contains request form-data file timesheet with value set to features/files/test.csv
-        And the context contains request form-data text projectId with value set to 123
+            And the context contains request form-data text projectId with value set to 123

--- a/features/features_lang/given/a_request_form_data_payload.feature
+++ b/features/features_lang/given/a_request_form_data_payload.feature
@@ -1,0 +1,11 @@
+Feature: Step given a request form-data payload
+    Validates the functionality of the given step "a request form-data payload"
+
+
+    Scenario: Sets the specified form-data payload in the context
+        Given a request form-data payload
+            | key      | value                    | type |
+            | timesheet  | features/files/test.csv  | file |
+            | projectId  | 123                      | text |
+        Then the context contains request form-data file timesheet with value set to features/files/test.csv
+        And the context contains request form-data text projectId with value set to 123

--- a/features/files/test.csv
+++ b/features/files/test.csv
@@ -1,2 +1,0 @@
-key,value
-foo,bar

--- a/features/files/test.csv
+++ b/features/files/test.csv
@@ -1,0 +1,2 @@
+key,value
+foo,bar

--- a/features/steps/lang_helper_steps.py
+++ b/features/steps/lang_helper_steps.py
@@ -42,6 +42,16 @@ def step_impl(context):
     assert_that(context.request_json_payload).is_equal_to(expected_payload)
 
 
+@then('the context contains request form-data text {key} with value set to {value}')
+def step_impl(context, key, value):
+    assert_that(context.request_form_data_payload[key]).is_equal_to(value)
+
+
+@then('the context contains request form-data file {key} with value set to {value}')
+def step_impl(context, key, value):
+    assert_that(context.request_files[key]).is_equal_to(value)
+
+
 @then('the session {name} property is {value}')
 def step_impl(context, name, value):
     expected_value = eval(value)

--- a/tests/test_lang_imp/test_request_builder.py
+++ b/tests/test_lang_imp/test_request_builder.py
@@ -16,7 +16,8 @@ class TestBuilderInterface(unittest.TestCase):
             'OBJECT_ID': 5,
             'OBJECT_NAME': 'resolved name',
             'PARAM1': 'resolved_param1',
-            'PARAM2': 'resolved_param2'
+            'PARAM2': 'resolved_param2',
+            'FILE_PATH': 'data/resolved_file.txt'
         }
         self.vars_manager = _definitions.VarsManager()
         self.vars_manager.add_vars(self.vars)
@@ -112,6 +113,42 @@ class TestBuilderInterface(unittest.TestCase):
         _builder.set_request_headers(self.context, actual_headers)
         assert_that(self.context.request_headers).is_equal_to(expected_headers)
 
+
+    def test_form_data_fields_are_set_in_context(self):
+        actual_form_data = FormDataTableDouble()
+        expected_form_data = {'description': 'a file'}
+        _builder.set_form_data(self.context, actual_form_data)
+        assert_that(self.context.request_form_data).is_equal_to(expected_form_data)
+
+
+    def test_form_data_file_fields_are_set_in_context(self):
+        actual_form_data = FormDataTableDouble()
+        expected_files = {'attachment': 'data/a_file.txt'}
+        _builder.set_form_data(self.context, actual_form_data)
+        assert_that(self.context.request_files).is_equal_to(expected_files)
+
+
+    def test_form_data_values_are_resolved(self):
+        actual_form_data = FormDataTableDouble(resolve_values=True)
+        _builder.set_form_data(self.context, actual_form_data)
+        assert_that(self.context.request_form_data).is_equal_to({'description': 'resolved name'})
+        assert_that(self.context.request_files).is_equal_to({'attachment': 'data/resolved_file.txt'})
+
+
+    def test_form_data_names_are_resolved(self):
+        actual_form_data = FormDataTableDouble(resolve_names=True)
+        _builder.set_form_data(self.context, actual_form_data)
+        assert_that(self.context.request_form_data).is_equal_to({'resolved_param1': 'foo'})
+        assert_that(self.context.request_files).is_equal_to({'resolved_param2': 'data/a_file.txt'})
+
+
+    def test_form_data_files_are_empty_when_no_file_fields(self):
+        actual_form_data = FormDataTableDouble(text_only=True)
+        _builder.set_form_data(self.context, actual_form_data)
+        assert_that(self.context.request_form_data).is_equal_to({'description': 'a file'})
+        assert_that(self.context.request_files).is_equal_to({})
+
+
 class ContextDouble(object):
     pass
 
@@ -143,6 +180,42 @@ class TableDouble(object):
             yield {'param': 'name',
                    'value': 'foo_bar'}
 
+
+class FormDataTableDouble(object):
+    def __init__(self, resolve_values=False, resolve_names=False, text_only=False):
+        self.resolve_values = resolve_values
+        self.resolve_names = resolve_names
+        self.text_only = text_only
+
+    def __iter__(self):
+        if self.resolve_values:
+            yield {'param': 'description',
+                   'value': '${OBJECT_NAME}',
+                   'type': 'text'}
+            yield {'param': 'attachment',
+                   'value': '${FILE_PATH}',
+                   'type': 'file'}
+
+        elif self.resolve_names:
+            yield {'param': '${PARAM1}',
+                   'value': 'foo',
+                   'type': 'text'}
+            yield {'param': '${PARAM2}',
+                   'value': 'data/a_file.txt',
+                   'type': 'file'}
+
+        elif self.text_only:
+            yield {'param': 'description',
+                   'value': 'a file',
+                   'type': 'text'}
+
+        else:
+            yield {'param': 'description',
+                   'value': 'a file',
+                   'type': 'text'}
+            yield {'param': 'attachment',
+                   'value': 'data/a_file.txt',
+                   'type': 'file'}
 
 
 if __name__=="__main__":

--- a/tests/test_lang_imp/test_request_builder.py
+++ b/tests/test_lang_imp/test_request_builder.py
@@ -117,35 +117,35 @@ class TestBuilderInterface(unittest.TestCase):
     def test_form_data_fields_are_set_in_context(self):
         actual_form_data = FormDataTableDouble()
         expected_form_data = {'description': 'a file'}
-        _builder.set_form_data(self.context, actual_form_data)
-        assert_that(self.context.request_form_data).is_equal_to(expected_form_data)
+        _builder.set_form_data_payload(self.context, actual_form_data)
+        assert_that(self.context.request_form_data_payload).is_equal_to(expected_form_data)
 
 
     def test_form_data_file_fields_are_set_in_context(self):
         actual_form_data = FormDataTableDouble()
         expected_files = {'attachment': 'data/a_file.txt'}
-        _builder.set_form_data(self.context, actual_form_data)
+        _builder.set_form_data_payload(self.context, actual_form_data)
         assert_that(self.context.request_files).is_equal_to(expected_files)
 
 
     def test_form_data_values_are_resolved(self):
         actual_form_data = FormDataTableDouble(resolve_values=True)
-        _builder.set_form_data(self.context, actual_form_data)
-        assert_that(self.context.request_form_data).is_equal_to({'description': 'resolved name'})
+        _builder.set_form_data_payload(self.context, actual_form_data)
+        assert_that(self.context.request_form_data_payload).is_equal_to({'description': 'resolved name'})
         assert_that(self.context.request_files).is_equal_to({'attachment': 'data/resolved_file.txt'})
 
 
     def test_form_data_names_are_resolved(self):
         actual_form_data = FormDataTableDouble(resolve_names=True)
-        _builder.set_form_data(self.context, actual_form_data)
-        assert_that(self.context.request_form_data).is_equal_to({'resolved_param1': 'foo'})
+        _builder.set_form_data_payload(self.context, actual_form_data)
+        assert_that(self.context.request_form_data_payload).is_equal_to({'resolved_param1': 'foo'})
         assert_that(self.context.request_files).is_equal_to({'resolved_param2': 'data/a_file.txt'})
 
 
     def test_form_data_files_are_empty_when_no_file_fields(self):
         actual_form_data = FormDataTableDouble(text_only=True)
-        _builder.set_form_data(self.context, actual_form_data)
-        assert_that(self.context.request_form_data).is_equal_to({'description': 'a file'})
+        _builder.set_form_data_payload(self.context, actual_form_data)
+        assert_that(self.context.request_form_data_payload).is_equal_to({'description': 'a file'})
         assert_that(self.context.request_files).is_equal_to({})
 
 
@@ -189,31 +189,31 @@ class FormDataTableDouble(object):
 
     def __iter__(self):
         if self.resolve_values:
-            yield {'param': 'description',
+            yield {'key': 'description',
                    'value': '${OBJECT_NAME}',
                    'type': 'text'}
-            yield {'param': 'attachment',
+            yield {'key': 'attachment',
                    'value': '${FILE_PATH}',
                    'type': 'file'}
 
         elif self.resolve_names:
-            yield {'param': '${PARAM1}',
+            yield {'key': '${PARAM1}',
                    'value': 'foo',
                    'type': 'text'}
-            yield {'param': '${PARAM2}',
+            yield {'key': '${PARAM2}',
                    'value': 'data/a_file.txt',
                    'type': 'file'}
 
         elif self.text_only:
-            yield {'param': 'description',
+            yield {'key': 'description',
                    'value': 'a file',
                    'type': 'text'}
 
         else:
-            yield {'param': 'description',
+            yield {'key': 'description',
                    'value': 'a file',
                    'type': 'text'}
-            yield {'param': 'attachment',
+            yield {'key': 'attachment',
                    'value': 'data/a_file.txt',
                    'type': 'file'}
 

--- a/tests/test_lang_imp/test_request_invoker.py
+++ b/tests/test_lang_imp/test_request_invoker.py
@@ -153,15 +153,6 @@ class TestRequestInvokerFileUpload(unittest.TestCase):
         self.context.request_files = {"attachment": self.file_path}
         self.context.request_form_data_payload = {"description": "a file"}
 
-    def _create_temp_file(self, suffix):
-        handle, path = tempfile.mkstemp(suffix=suffix)
-        with os.fdopen(handle, "wb") as f: f.write(b"file content")
-        self.addCleanup(os.remove, path)
-        return path
-
-    def _sent_file(self, field="attachment"):
-        return self.session.request_files[field]
-
     # send_post()
     def test_invokes_post_on_session(self):
         _invoker.send_post(self.context)
@@ -237,6 +228,15 @@ class TestRequestInvokerFileUpload(unittest.TestCase):
     def test_patch_stores_response_in_context(self):
         _invoker.send_patch(self.context)
         assert_that(self.context.response).is_same_as(self.response)
+
+    def _create_temp_file(self, suffix):
+        handle, path = tempfile.mkstemp(suffix=suffix)
+        with os.fdopen(handle, "wb") as f: f.write(b"file content")
+        self.addCleanup(os.remove, path)
+        return path
+
+    def _sent_file(self, field="attachment"):
+        return self.session.request_files[field]
 
 
 class SessionDouble(object):

--- a/tests/test_lang_imp/test_request_invoker.py
+++ b/tests/test_lang_imp/test_request_invoker.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import unittest
 
 from assertpy import assert_that
@@ -136,6 +138,107 @@ class TestRequestInvokerInterface(unittest.TestCase):
         )
 
 
+class TestRequestInvokerFileUpload(unittest.TestCase):
+    def setUp(self):
+        super(TestRequestInvokerFileUpload, self).setUp()
+        self.response = ResponseDouble()
+        self.session = SessionDouble()
+        self.session.response = self.response
+        self.context = ContextDouble()
+        self.context.session = self.session
+        self.context.request_url = "http://my.server.com/resource"
+        self.context.request_params = {"foo": 56, "bar": "baz"}
+        self.context.request_headers = {"foo": 56, "bar": "baz"}
+        self.file_path = self._create_temp_file(suffix=".txt")
+        self.context.request_files = {"attachment": self.file_path}
+        self.context.request_form_data = {"description": "a file"}
+
+    def _create_temp_file(self, suffix):
+        handle, path = tempfile.mkstemp(suffix=suffix)
+        with os.fdopen(handle, "wb") as f: f.write(b"file content")
+        self.addCleanup(os.remove, path)
+        return path
+
+    def _sent_file(self, field="attachment"):
+        return self.session.request_files[field]
+
+    # send_post()
+    def test_invokes_post_on_session(self):
+        _invoker.send_post(self.context)
+        assert_that(self.session.post_invoked).is_true()
+        assert_that(self.session.request_url).is_equal_to(self.context.request_url)
+
+    def test_post_stores_response_in_context(self):
+        _invoker.send_post(self.context)
+        assert_that(self.context.response).is_same_as(self.response)
+
+    def test_post_request_includes_params(self):
+        _invoker.send_post(self.context)
+        assert_that(self.session.request_params).is_same_as(self.context.request_params)
+
+    def test_post_request_includes_headers(self):
+        _invoker.send_post(self.context)
+        assert_that(self.session.request_headers).is_same_as(self.context.request_headers)
+
+    def test_sends_file_with_name_and_content_type(self):
+        _invoker.send_post(self.context)
+        file_name, file_object, content_type = self._sent_file()
+        assert_that(file_name).is_equal_to(os.path.basename(self.file_path))
+        assert_that(file_object.name).is_equal_to(self.file_path)
+        assert_that(content_type).is_equal_to("text/plain")
+
+    def test_defaults_content_type_when_it_cannot_be_guessed(self):
+        path = self._create_temp_file(suffix=".unknown")
+        self.context.request_files = {"attachment": path}
+        _invoker.send_post(self.context)
+        _, _, content_type = self._sent_file()
+        assert_that(content_type).is_equal_to("application/octet-stream")
+
+    def test_sends_form_data_with_files(self):
+        _invoker.send_post(self.context)
+        assert_that(self.session.request_data).is_same_as(self.context.request_form_data)
+
+    def test_form_data_is_optional(self):
+        del self.context.request_form_data
+        _invoker.send_post(self.context)
+        assert_that(self.session.request_data).is_none()
+
+    def test_does_not_send_json_payload_with_files(self):
+        _invoker.send_post(self.context)
+        assert_that(self.session.request_json).is_none()
+
+    def test_closes_files_after_request(self):
+        _invoker.send_post(self.context)
+        _, file_object, _ = self._sent_file()
+        assert_that(file_object.closed).is_true()
+
+    # send_put()
+    def test_invokes_put_with_files(self):
+        _invoker.send_put(self.context)
+        assert_that(self.session.put_invoked).is_true()
+        file_name, _, content_type = self._sent_file()
+        assert_that(file_name).is_equal_to(os.path.basename(self.file_path))
+        assert_that(content_type).is_equal_to("text/plain")
+        assert_that(self.session.request_data).is_same_as(self.context.request_form_data)
+
+    def test_put_stores_response_in_context(self):
+        _invoker.send_put(self.context)
+        assert_that(self.context.response).is_same_as(self.response)
+
+    # send_patch()
+    def test_invokes_patch_with_files(self):
+        _invoker.send_patch(self.context)
+        assert_that(self.session.patch_invoked).is_true()
+        file_name, _, content_type = self._sent_file()
+        assert_that(file_name).is_equal_to(os.path.basename(self.file_path))
+        assert_that(content_type).is_equal_to("text/plain")
+        assert_that(self.session.request_data).is_same_as(self.context.request_form_data)
+
+    def test_patch_stores_response_in_context(self):
+        _invoker.send_patch(self.context)
+        assert_that(self.context.response).is_same_as(self.response)
+
+
 class SessionDouble(object):
     def __init__(self):
         self.response = None
@@ -149,6 +252,7 @@ class SessionDouble(object):
         self.request_params = None
         self.request_data = None
         self.request_json = None
+        self.request_files = None
         self.request_kwargs = None
 
     def get(self, url, params=None, headers=None, **kwargs):
@@ -159,32 +263,35 @@ class SessionDouble(object):
         self.request_kwargs = kwargs
         return self.response
 
-    def post(self, url, data=None, json=None, params=None, headers=None, **kwargs):
+    def post(self, url, data=None, json=None, params=None, headers=None, files=None, **kwargs):
         self.post_invoked = True
         self.request_url = url
         self.request_headers = headers
         self.request_data = data
         self.request_json = json
         self.request_params = params
+        self.request_files = files
         self.request_kwargs = kwargs
         return self.response
 
-    def put(self, url, data=None, params=None, headers=None, **kwargs):
+    def put(self, url, data=None, params=None, headers=None, files=None, **kwargs):
         self.put_invoked = True
         self.request_url = url
         self.request_headers = headers
         self.request_data = data
         self.request_params = params
+        self.request_files = files
         self.request_kwargs = kwargs
         return self.response
 
-    def patch(self, url, data=None, json=None, params=None, headers=None, **kwargs):
+    def patch(self, url, data=None, json=None, params=None, headers=None, files=None, **kwargs):
         self.patch_invoked = True
         self.request_url = url
         self.request_headers = headers
         self.request_data = data
         self.request_json = json
         self.request_params = params
+        self.request_files = files
         self.request_kwargs = kwargs
         return self.response
 

--- a/tests/test_lang_imp/test_request_invoker.py
+++ b/tests/test_lang_imp/test_request_invoker.py
@@ -151,7 +151,7 @@ class TestRequestInvokerFileUpload(unittest.TestCase):
         self.context.request_headers = {"foo": 56, "bar": "baz"}
         self.file_path = self._create_temp_file(suffix=".txt")
         self.context.request_files = {"attachment": self.file_path}
-        self.context.request_form_data = {"description": "a file"}
+        self.context.request_form_data_payload = {"description": "a file"}
 
     def _create_temp_file(self, suffix):
         handle, path = tempfile.mkstemp(suffix=suffix)
@@ -196,10 +196,10 @@ class TestRequestInvokerFileUpload(unittest.TestCase):
 
     def test_sends_form_data_with_files(self):
         _invoker.send_post(self.context)
-        assert_that(self.session.request_data).is_same_as(self.context.request_form_data)
+        assert_that(self.session.request_data).is_same_as(self.context.request_form_data_payload)
 
     def test_form_data_is_optional(self):
-        del self.context.request_form_data
+        del self.context.request_form_data_payload
         _invoker.send_post(self.context)
         assert_that(self.session.request_data).is_none()
 
@@ -219,7 +219,7 @@ class TestRequestInvokerFileUpload(unittest.TestCase):
         file_name, _, content_type = self._sent_file()
         assert_that(file_name).is_equal_to(os.path.basename(self.file_path))
         assert_that(content_type).is_equal_to("text/plain")
-        assert_that(self.session.request_data).is_same_as(self.context.request_form_data)
+        assert_that(self.session.request_data).is_same_as(self.context.request_form_data_payload)
 
     def test_put_stores_response_in_context(self):
         _invoker.send_put(self.context)
@@ -232,7 +232,7 @@ class TestRequestInvokerFileUpload(unittest.TestCase):
         file_name, _, content_type = self._sent_file()
         assert_that(file_name).is_equal_to(os.path.basename(self.file_path))
         assert_that(content_type).is_equal_to("text/plain")
-        assert_that(self.session.request_data).is_same_as(self.context.request_form_data)
+        assert_that(self.session.request_data).is_same_as(self.context.request_form_data_payload)
 
     def test_patch_stores_response_in_context(self):
         _invoker.send_patch(self.context)

--- a/tests/test_lang_imp/test_request_invoker.py
+++ b/tests/test_lang_imp/test_request_invoker.py
@@ -148,7 +148,7 @@ class TestRequestInvokerFileUpload(unittest.TestCase):
         self.context.session = self.session
         self.context.request_url = "http://my.server.com/resource"
         self.context.request_params = {"foo": 56, "bar": "baz"}
-        self.context.request_headers = {"foo": 56, "bar": "baz"}
+        self.context.request_headers = {"baz": 57, "qux": "quux"}
         self.file_path = self._create_temp_file(suffix=".txt")
         self.context.request_files = {"attachment": self.file_path}
         self.context.request_form_data_payload = {"description": "a file"}


### PR DESCRIPTION
## Feature
- Allow clients to send payload as `form-data` as `key-value` pairs for sending files
like this
- Add both unit/feature test for this feature
```
Given a request form-data payload
| key            | value                             | type |
| timesheet      | features/files/test.csv           | file |
| projectId      | 123                               | text |
```

## Enhancements
- I noticed that request invokers `send_post`, `send_put` and `send_patch` are shared the same logic so I refactored it to remove redundancy


## Checklist
- [x] I followed the package convention for code style
- [x] All unit tests are passed
- [x] All feature tests are passed

