### PR TITLE
removed python 3.7 from validation

### DIFF
--- a/.github/workflows/python-release-pypi.yml
+++ b/.github/workflows/python-release-pypi.yml
@@ -13,9 +13,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/.github/workflows/python-verify-library.yml
+++ b/.github/workflows/python-verify-library.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v3
@@ -38,4 +38,4 @@ jobs:
         make -C docs html
     - name: Build Package
       run: python setup.py bdist_wheel sdist
-        
+

--- a/boltfile.py
+++ b/boltfile.py
@@ -7,7 +7,7 @@ bolt.register_module_tasks(bolt_br)
 
 # DEVELOPMENT TASKS
 bolt.register_task('default', [
-    'pip',
+    # 'pip',
     'run-unit-tests',
     'run-feature-tests'
 ])
@@ -128,7 +128,7 @@ config = {
             'options': {
                 'format': 'progress2',
                 'tags': [
-                    ['~@disabled'], 
+                    ['~@disabled'],
                     ['~@wip']
                 ],
                 'junit': True,


### PR DESCRIPTION
The Python 3.7 version fails because it's not available in the runners. This project needs to be migrated to newer versions of Python, so I'm disabling the version now.